### PR TITLE
Add Device Routes

### DIFF
--- a/src/data/map.js
+++ b/src/data/map.js
@@ -835,8 +835,10 @@ const getSpawnpoints = async (minLat, maxLat, minLon, maxLon, updated, spawnpoin
 
 const getDevices = async () => {
     const sql = `
-    SELECT uuid, instance_name, last_host, last_seen, account_username, last_lat, last_lon, device_group
+    SELECT uuid, instance_name, last_host, last_seen, account_username, last_lat, last_lon, device_group, type, data
     FROM device
+    INNER JOIN instance
+    ON device.instance_name = instance.name
     `;
     const results = await db.query(sql);
     let devices = [];
@@ -851,7 +853,9 @@ const getDevices = async () => {
                 account_username: result.account_username,
                 last_lat: result.last_lat,
                 last_lon: result.last_lon,
-                device_group: result.device_group
+                device_group: result.device_group,
+                type: result.type,
+                data: result.data
             });
         }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ const utils = require('./services/utils.js');
 // TODO: Only clear layers if filter changed
 // TODO: Reset all settings (clear cache/session)
 // TODO: Finish default filter options
+// TODO: Click device, show 70m instance
 
 // Basic security protection middleware
 app.use(helmet());

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -3751,9 +3751,21 @@ function getDeviceMarker (device, ts) {
         virtual: true
     });
     marker.bindPopup('');
+    let polyline;
     marker.on('popupopen', function (popup) {
         openedDevice = device;
         marker._popup.setContent(getDevicePopupContent(device));
+        if (device.type === 'circle_pokemon') {
+            const data = JSON.parse(device.data);
+            const route = data.area;
+            // TODO: Make outline color configurable
+            polyline = L.polyline(route, {color: 'red'}).addTo(map);
+        }
+    });
+    marker.on('popupclose', function (popup) {
+        if (polyline) {
+            map.removeLayer(polyline);
+        }
     });
     return marker;
 }


### PR DESCRIPTION
Adds device routes to the map upon click/tap for circle_pokemon instances, upon closing the popup or clicking the device marker again the route will be removed.  

Example:  
![image](https://user-images.githubusercontent.com/1327440/89750514-39962900-da81-11ea-8ce4-2c3fc7af23d1.png)
