### PR TITLE
Fix missing timestamp

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -145,6 +145,7 @@ const handlePage = async (req, res) => {
     data.page_is_home = true;
     data.page_is_areas = true;
     data.show_areas = true;
+    data.timestamp = Date.now();
     let lat = parseFloat(req.params.lat || config.map.startLat);
     let lon = parseFloat(req.params.lon || config.map.startLon);
     let city = req.params.city || null;


### PR DESCRIPTION
This is consistent with what RDM does but does not take advantage of cache. A better way might be to use some kind of version number, perhaps a hash of `git describe`?