### PR TITLE
Config Discord Status

### DIFF
--- a/src/config.example.json
+++ b/src/config.example.json
@@ -73,6 +73,7 @@
     },
     "discord": {
         "enabled": true,
+        "status": "Map Status: Online",
         "botToken": "",
         "clientId": "",
         "clientSecret": "",

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -11,12 +11,8 @@ const client = new Discord.Client();
 
 client.on('ready', () => {
     console.log(`Logged in as ${client.user.tag}!`);
-});
-  
-client.on('message', (msg) => {
-    if (msg.content === 'ping') {
-        msg.reply('pong');
-    }
+    client.user.setPresence({ activity: { name: config.discord.status, type: 3 }
+    });
 });
   
 client.login(config.discord.botToken);


### PR DESCRIPTION
Adds config option to set a custom Discord bot status. Default set to showing that the map is currently online.

Also removed ping/pong stuff that I'm guessing was just left behind from initial testing :smile: