### PR TITLE
Move search button to topleft

### DIFF
--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -1747,7 +1747,7 @@ function initMap () {
 
     const CustomControlSearch = L.Control.extend({
         options: {
-            position: 'topright'
+            position: 'topleft'
         },
         onAdd: function (map) {
             const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');


### PR DESCRIPTION
Otherwise it will cover the popup close button, especially on phones.