### PR TITLE
Fix weird league stats error

### DIFF
--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -2570,10 +2570,12 @@ function hasRelevantLeagueStats (leagueStats, greatLeague) {
     var minCP = greatLeague !== false ? 1400 : 2400;
     var maxCP = greatLeague !== false ? 1500 : 2500;
     var maxRank = 100;
-    for (var i = 0; i < leagueStats.length; i++) {
-        if (leagueStats[i].rank <= maxRank && leagueStats[i].cp >= minCP && leagueStats[i].cp <= maxCP) {
-            found = true;
-            break;
+    if (leagueStats) {
+        for (var i = 0; i < leagueStats.length; i++) {
+            if (leagueStats[i].rank <= maxRank && leagueStats[i].cp >= minCP && leagueStats[i].cp <= maxCP) {
+                found = true;
+                break;
+            }
         }
     }
     return found;


### PR DESCRIPTION
Check if leagueStats is undefined or null before looping through and checking for relevant pvp stats