### PR TITLE
New pokemon iconset

### DIFF
--- a/src/data/map.js
+++ b/src/data/map.js
@@ -351,7 +351,7 @@ const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = 
             raid_spawn_timestamp, raid_battle_timestamp, raid_pokemon_id, enabled, availble_slots, updated,
             raid_level, ex_raid_eligible, in_battle, raid_pokemon_move_1, raid_pokemon_move_2, raid_pokemon_form,
             raid_pokemon_cp, raid_pokemon_gender, raid_is_exclusive, cell_id, total_cp, sponsor_id,
-            raid_pokemon_evolution
+            raid_pokemon_evolution, raid_pokemon_costume
     FROM gym
     WHERE lat >= ? AND lat <= ? AND lon >= ? AND lon <= ? AND updated > ? AND deleted = false
         ${excludeLevelSQL} AND (
@@ -419,7 +419,8 @@ const getGyms = async (minLat, maxLat, minLon, maxLon, updated = 0, showRaids = 
                 cell_id: result.cell_id,
                 total_cp: result.total_cp,
                 sponsor_id: result.sponsor_id,
-                raid_pokemon_evolution: result.raid_pokemon_evolution
+                raid_pokemon_evolution: result.raid_pokemon_evolution,
+                raid_pokemon_costume: result.raid_pokemon_costume,
             });
         }
     }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -222,7 +222,7 @@ const getData = async (perms, filter) => {
                     'sort': i + 5
                 },
                 'name': sizeString,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(i === 0 ? 129 : 19, '0')}" style="height:50px; width:50px;">`,
+                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(i === 0 ? 129 : 19)}" style="height:50px; width:50px;">`,
                 'filter': filter,
                 'size': size,
                 'type': globalFiltersString
@@ -510,7 +510,7 @@ const getData = async (perms, filter) => {
                     'sort': pokeId + 2000
                 },
                 'name': i18n.__('poke_' + pokeId),
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(pokeId, '0')}" style="height:50px; width:50px;">`,
+                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(pokeId)}" style="height:50px; width:50px;">`,
                 'filter': generateShowHideButtons(pokeId, 'quest-pokemon'),
                 'size': generateSizeButtons(pokeId, 'quest-pokemon'),
                 'type': pokemonTypeString
@@ -663,7 +663,7 @@ const getData = async (perms, filter) => {
                     'sort': id
                 },
                 'name': i18n.__('poke_' + id),
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(id, '0')}" style="height:50px; width:50px;">`,
+                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(id)}" style="height:50px; width:50px;">`,
                 'filter': generateShowHideButtons(id, 'nest-pokemon'),
                 'size': generateSizeButtons(id, 'nest-pokemon'),
                 'type': pokemonString
@@ -767,9 +767,9 @@ const generateSizeButtons = (id, type) => {
     return size;
 };
 
-const getPokemonIcon = (pokemonId, formId) => {
+const getPokemonIcon = (pokemonId, formId = 0) => {
     let pokeId = utils.zeroPad(pokemonId, 3);
-    let form = formId === '0' ? '00' : formId;
+    let form = formId || masterfile.pokemon[pokemonId].default_form_id;
     return `pokemon_icon_${pokeId}_${form}.png`;
 };
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -68,7 +68,6 @@ const getData = async (perms, filter) => {
     const showNestFilter = filter.show_nest_filter && filter.show_nest_filter !== 'false' || false;
     const showWeatherFilter = filter.show_weather_filter && filter.show_weather_filter !== 'false' || false;
     const showDeviceFilter = filter.show_device_filter && filter.show_device_filter !== 'false' || false;
-    const iconStyle = filter.icon_style || 'Default';
     const lastUpdate = filter.last_update || 0;
     if ((showGyms || showRaids || showPokestops || showQuests || showInvasions || showPokemon || showSpawnpoints ||
         showCells || showSubmissionTypeCells || showSubmissionPlacementCells || showWeather || showNests || showActiveDevices) &&
@@ -94,7 +93,6 @@ const getData = async (perms, filter) => {
     const permShowSubmissionCells = perms ? perms.submissionCells !== false : true;
     const permShowWeather = perms ? perms.weather !== false : true;
     const permShowNests = perms ? perms.nests !== false : true;
-    const iconStylePath = config.icons[iconStyle].path;
 
     let data = {};
     if ((permShowGyms && showGyms) || (permShowRaids && showRaids)) {
@@ -222,7 +220,10 @@ const getData = async (perms, filter) => {
                     'sort': i + 5
                 },
                 'name': sizeString,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(i === 0 ? 129 : 19)}" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'pokemon',
+                    pokemonId: i === 0 ? 129 : 19
+                },
                 'filter': filter,
                 'size': size,
                 'type': globalFiltersString
@@ -261,7 +262,11 @@ const getData = async (perms, filter) => {
                         'sort': i * 100 + j
                     },
                     'name': i18n.__('poke_' + i) + (formId === '0' ? '' : ' ' + formName),
-                    'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(i, formId)}" style="height:50px; width:50px;">`,
+                    'image': {
+                        type: 'pokemon',
+                        pokemonId: i,
+                        form: formId
+                    },
                     'filter': filter,
                     'size': size,
                     'type': pokemonTypeString
@@ -284,7 +289,10 @@ const getData = async (perms, filter) => {
                 'sort': 0
             },
             'name': raidTimers,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/misc/timer.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/misc/timer.png'
+            },
             'filter': generateShowHideButtons('timers', 'raid-timers'),
             'size': generateSizeButtons('timers', 'raid-timers'),
             'type': generalString
@@ -299,7 +307,10 @@ const getData = async (perms, filter) => {
                     'sort': i
                 },
                 'name': raidLevel,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/egg/${i}.png" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'img',
+                    path: `/egg/${i}.png`
+                },
                 'filter': generateShowHideButtons(i, 'raid-level'),
                 'size': generateSizeButtons(i, 'raid-level'),
                 'type': raidLevelsString
@@ -322,7 +333,11 @@ const getData = async (perms, filter) => {
                     'sort': i+200
                 },
                 'name': i18n.__('poke_' + pokemonId) + (formId === '0' ? '' : ' ' + formName),
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(pokemonId, formId)}" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'pokemon',
+                    pokemonId: pokemonId,
+                    form: formId
+                },
                 'filter': generateShowHideButtons(id, 'raid-pokemon'),
                 'size': generateSizeButtons(id, 'raid-pokemon'),
                 'type': pokemonString
@@ -346,7 +361,10 @@ const getData = async (perms, filter) => {
                     'sort': i
                 },
                 'name': gymTeam,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/gym/${i}_${i}.png" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'img',
+                    path: `gym/${i}_${i}.png`
+                },
                 'filter': generateShowHideButtons(i, 'gym-team'),
                 'size': generateSizeButtons(i, 'gym-team'),
                 'type': gymTeamString
@@ -360,7 +378,10 @@ const getData = async (perms, filter) => {
                 'sort': 5
             },
             'name': i18n.__('filter_raid_ex') ,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/item/1403.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/item/1403.png'
+            },
             'filter': generateShowHideButtons('ex', 'gym-ex'),
             'size': generateSizeButtons('ex', 'gym-ex'),
             'type': gymOptionsString
@@ -373,7 +394,10 @@ const getData = async (perms, filter) => {
                 'sort': 6
             },
             'name': i18n.__('filter_gym_in_battle') ,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/battle/0_0.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/battle/0_0.png'
+            },
             'filter': generateShowHideButtons('battle', 'gym-battle'),
             'size': generateSizeButtons('battle', 'gym-battle'),
             'type': gymOptionsString
@@ -389,7 +413,10 @@ const getData = async (perms, filter) => {
                     'sort': i + 100
                 },
                 'name': availableSlots,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/gym/${(i == 6 ? 0 : team)}_${(6 - i)}.png" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'img',
+                    path: `/gym/${i == 6 ? 0 : team}_${6 - i}.png`
+                },
                 'filter': generateShowHideButtons(i, 'gym-slots'),
                 'size': generateSizeButtons(i, 'gym-slots'),
                 'type': availableSlotsString
@@ -428,7 +455,10 @@ const getData = async (perms, filter) => {
                 'sort': 0
             },
             'name': globalCandyString,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/item/1301.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/item/1301.png'
+            },
             'filter': candyFilter,
             'size': candySize,
             'type': globalFiltersString
@@ -451,7 +481,10 @@ const getData = async (perms, filter) => {
                 'sort': 1
             },
             'name': globalStardustString,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/item/-1.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/item/-1.png'
+            },
             'filter': stardustFilter,
             'size': stardustSize,
             'type': globalFiltersString
@@ -477,7 +510,10 @@ const getData = async (perms, filter) => {
                     'sort': i
                 },
                 'name': itemName,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/item/${-i}.png" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'img',
+                    path: `/item/${-i}.png`
+                },
                 'filter': generateShowHideButtons(i, 'quest-misc'),
                 'size': generateSizeButtons(i, 'quest-misc'),
                 'type': miscTypeString
@@ -494,7 +530,10 @@ const getData = async (perms, filter) => {
                     'sort': itemId + 100
                 },
                 'name': i18n.__('item_' + itemId) ,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/item/${itemId}.png" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'img',
+                    path: `/item/${itemId}.png`
+                },
                 'filter': generateShowHideButtons(itemId, 'quest-item'),
                 'size': generateSizeButtons(itemId, 'quest-item'),
                 'type': itemsTypeString
@@ -510,7 +549,10 @@ const getData = async (perms, filter) => {
                     'sort': pokeId + 2000
                 },
                 'name': i18n.__('poke_' + pokeId),
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(pokeId)}" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'pokemon',
+                    pokemonId: pokeId
+                },
                 'filter': generateShowHideButtons(pokeId, 'quest-pokemon'),
                 'size': generateSizeButtons(pokeId, 'quest-pokemon'),
                 'type': pokemonTypeString
@@ -529,7 +571,10 @@ const getData = async (perms, filter) => {
                 'sort': 0
             },
             'name': pokestopNormal,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/pokestop/0.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/pokestop/0.png'
+            },
             'filter': generateShowHideButtons('normal', 'pokestop-normal'),
             'size': generateSizeButtons('normal', 'pokestop-normal'),
             'type': pokestopOptionsString
@@ -544,7 +589,10 @@ const getData = async (perms, filter) => {
                         'sort': i
                     },
                     'name': pokestopLure,
-                    'image': `<img class="lazy_load" data-src="${iconStylePath}/pokestop/${i}.png" style="height:50px; width:50px;">`,
+                    'image': {
+                        type: 'img',
+                        path: `/pokestop/${i}.png`
+                    },
                     'filter': generateShowHideButtons(i, 'pokestop-lure'),
                     'size': generateSizeButtons(i, 'pokestop-lure'),
                     'type': pokestopOptionsString
@@ -566,7 +614,10 @@ const getData = async (perms, filter) => {
                 'sort': 0
             },
             'name': invasionTimers,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/misc/timer.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/misc/timer.png'
+            },
             'filter': generateShowHideButtons('timers', 'invasion-timers'),
             'size': generateSizeButtons('timers', 'invasion-timers'),
             'type': generalString
@@ -580,7 +631,10 @@ const getData = async (perms, filter) => {
                     'sort': i
                 },
                 'name': i18n.__('grunt_' + i),
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/grunt/${i}.png" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'img',
+                    path: `/grunt/${i}.png`
+                },
                 'filter': generateShowHideButtons(i, 'invasion-grunt'),
                 'size': generateSizeButtons(i, 'invasion-grunt'),
                 'type': gruntTypeString
@@ -601,7 +655,10 @@ const getData = async (perms, filter) => {
                 'sort': 0
             },
             'name': spawnpointWithoutTimerString,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/spawnpoint/0.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/spawnpoint/0.png'
+            },
             'filter': generateShowHideButtons('no-timer', 'spawnpoint-timer'),
             'size': generateSizeButtons('no-timer', 'spawnpoint-timer'),
             'type': spawnpointOptionsString
@@ -613,7 +670,10 @@ const getData = async (perms, filter) => {
                 'sort': 1
             },
             'name': spawnpointWithTimerString,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/spawnpoint/1.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/spawnpoint/1.png'
+            },
             'filter': generateShowHideButtons('with-timer', 'spawnpoint-timer'),
             'size': generateSizeButtons('with-timer', 'spawnpoint-timer'),
             'type': spawnpointOptionsString
@@ -647,7 +707,7 @@ const getData = async (perms, filter) => {
                 'sort': 0
             },
             'name': globalAverageString,
-            'image': `AVG`,
+            'image': 'AVG',
             'filter': filter,
             'size': size,
             'type': globalFiltersString
@@ -663,7 +723,10 @@ const getData = async (perms, filter) => {
                     'sort': id
                 },
                 'name': i18n.__('poke_' + id),
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/pokemon/${getPokemonIcon(id)}" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'pokemon',
+                    pokemonId: id
+                },
                 'filter': generateShowHideButtons(id, 'nest-pokemon'),
                 'size': generateSizeButtons(id, 'nest-pokemon'),
                 'type': pokemonString
@@ -683,7 +746,10 @@ const getData = async (perms, filter) => {
                     'sort': 0
                 },
                 'name': weatherNameString,
-                'image': `<img class="lazy_load" data-src="${iconStylePath}/weather/${i}.png" style="height:50px; width:50px;">`,
+                'image': {
+                    type: 'img',
+                    path: `/weather/${i}.png`
+                },
                 'filter': generateShowHideButtons(i, 'weather-type'),
                 'size': generateSizeButtons(i, 'weather-type'),
                 'type': weatherOptionsString
@@ -704,7 +770,10 @@ const getData = async (perms, filter) => {
                 'sort': 0
             },
             'name': deviceOnlineString,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/device/0.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/device/0.png'
+            },
             'filter': generateShowHideButtons('online', 'device-status'),
             'size': generateSizeButtons('online', 'device-status'),
             'type': deviceOptionsString
@@ -716,7 +785,10 @@ const getData = async (perms, filter) => {
                 'sort': 1
             },
             'name': deviceOfflineString,
-            'image': `<img class="lazy_load" data-src="${iconStylePath}/device/1.png" style="height:50px; width:50px;">`,
+            'image': {
+                type: 'img',
+                path: '/device/1.png'
+            },
             'filter': generateShowHideButtons('offline', 'device-status'),
             'size': generateSizeButtons('offline', 'device-status'),
             'type': deviceOptionsString
@@ -765,12 +837,6 @@ const generateSizeButtons = (id, type) => {
     </div>
     `;
     return size;
-};
-
-const getPokemonIcon = (pokemonId, formId = 0) => {
-    let pokeId = utils.zeroPad(pokemonId, 3);
-    let form = formId || masterfile.pokemon[pokemonId].default_form_id;
-    return `pokemon_icon_${pokeId}_${form}.png`;
 };
 
 module.exports = router;

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -204,11 +204,9 @@ const handleHomeJs = async (req, res) => {
     const tileservers = getAvailableTileservers();
     data.available_tileservers_json = JSON.stringify(tileservers);
 
-    data.available_icon_styles_json = JSON.stringify(config.icons);
-
     // Build available forms list
-    const availableForms = await getAvailableForms();
-    data.available_forms_json = JSON.stringify(availableForms);
+    await updateAvailableForms(config.icons);
+    data.available_icon_styles_json = JSON.stringify(config.icons);
 
     // Build available items list
     const availableItems = [-3, -2, -1];
@@ -256,21 +254,23 @@ const getAvailableTileservers = () => {
     return tileservers;
 };
 
-const getAvailableForms = async () => {
-    const availableForms = [];
-    // TODO: Check icon repos, hopefully no one uses all remote icon repos :joy:
-    // TODO: who puts :joy: in a comment???
-    const pokemonIconsDir = path.resolve(__dirname, '../../static/img/pokemon');
-    const files = await fs.promises.readdir(pokemonIconsDir);
-    if (files) {
-        files.forEach(file => {
-            const match = /^pokemon_icon_(.+)\.png$/.exec(file);
-            if (match !== null) {
-                availableForms.push(match[1]);
+const updateAvailableForms = async (icons) => {
+    for (const icon of Object.values(icons)) {
+        if (icon.path.startsWith('/')) {
+            const pokemonIconsDir = path.resolve(__dirname, `../../static${icon.path}/pokemon`);
+            const files = await fs.promises.readdir(pokemonIconsDir);
+            if (files) {
+                const availableForms = [];
+                files.forEach(file => {
+                    const match = /^pokemon_icon_(.+)\.png$/.exec(file);
+                    if (match !== null) {
+                        availableForms.push(match[1]);
+                    }
+                });
+                icon.pokemonList = availableForms;
             }
-        });
+        }
     }
-    return availableForms;
 };
 
 module.exports = router;

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -262,12 +262,11 @@ const getAvailableForms = async () => {
     // TODO: who puts :joy: in a comment???
     const pokemonIconsDir = path.resolve(__dirname, '../../static/img/pokemon');
     const files = await fs.promises.readdir(pokemonIconsDir);
-    const matcher = /^pokemon_icon_(.+)\.png$/.compile();
     if (files) {
         files.forEach(file => {
-            const match = matcher.exec(file);
+            const match = /^pokemon_icon_(.+)\.png$/.exec(file);
             if (match !== null) {
-                availableForms.push(match.groups[1]);
+                availableForms.push(match[1]);
             }
         });
     }

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -83,10 +83,6 @@ const handlePage = async (req, res) => {
 
     data.available_icon_styles_json = JSON.stringify(config.iconStyles);
 
-    // Build available forms list
-    const availableForms = getAvailableForms();
-    data.available_forms_json = JSON.stringify(availableForms);
-
     // Build available items list
     const availableItems = [-3, -2, -1];
     //const keys = Object.keys(InventoryItemId);
@@ -211,7 +207,7 @@ const handleHomeJs = async (req, res) => {
     data.available_icon_styles_json = JSON.stringify(config.icons);
 
     // Build available forms list
-    const availableForms = getAvailableForms();
+    const availableForms = await getAvailableForms();
     data.available_forms_json = JSON.stringify(availableForms);
 
     // Build available items list
@@ -260,27 +256,18 @@ const getAvailableTileservers = () => {
     return tileservers;
 };
 
-const getAvailableForms = () => {
+const getAvailableForms = async () => {
     const availableForms = [];
     // TODO: Check icon repos, hopefully no one uses all remote icon repos :joy:
+    // TODO: who puts :joy: in a comment???
     const pokemonIconsDir = path.resolve(__dirname, '../../static/img/pokemon');
-    const files = fs.readdirSync(pokemonIconsDir);
+    const files = await fs.promises.readdir(pokemonIconsDir);
+    const matcher = /^pokemon_icon_(.+)\.png$/.compile();
     if (files) {
         files.forEach(file => {
-            const split = file.replace('.png', '').split('_');
-            if (split.length === 5) {
-                const pokemonId = parseInt(split[2]);
-                const formId = parseInt(split[3]);
-                const evolutionId = parseInt(split[4]);
-                if (evolutionId > 0) {
-                    availableForms.push(`${pokemonId}-${formId}-${evolutionId}`);    
-                } else { 
-                    availableForms.push(`${pokemonId}-${formId}`); // TODO: Costumes?
-                }
-            } else if (split.length === 4) {
-                const pokemonId = parseInt(split[2]);
-                const formId = parseInt(split[3]);
-                availableForms.push(`${pokemonId}-${formId}`);
+            const match = matcher.exec(file);
+            if (match !== null) {
+                availableForms.push(match.groups[1]);
             }
         });
     }

--- a/src/views/index-css.mustache
+++ b/src/views/index-css.mustache
@@ -257,12 +257,18 @@ fieldset[disabled] .btn-size.active {
     border: 4px solid gray;
 }
 
+.filter-image-holder {
+    width: 50px;
+    height: 50px;
+}
 .marker-image-holder {
     position: absolute;
     width: 100%;
     height: 100%;
 }
-.marker-image-holder > img, .leaflet-container .leaflet-marker-pane .marker-image-holder > img {
+.filter-image-holder > img,
+.marker-image-holder > img,
+.leaflet-container .leaflet-marker-pane .marker-image-holder > img {
     position: absolute;
     max-width: 100% !important;
     max-height: 100% !important;

--- a/src/views/index-css.mustache
+++ b/src/views/index-css.mustache
@@ -292,6 +292,11 @@ fieldset[disabled] .btn-size.active {
     top: auto;
 }
 
+img {
+    image-rendering: crisp-edges;
+    image-rendering: -webkit-optimize-contrast;
+}
+
 @media (max-height: 600px) {
     .fill {
         top: 0;

--- a/src/views/index-css.mustache
+++ b/src/views/index-css.mustache
@@ -257,6 +257,11 @@ fieldset[disabled] .btn-size.active {
     border: 4px solid gray;
 }
 
+.pokemon-popup-image-holder {
+    width: 64px;
+    height: 64px;
+    margin: auto;
+}
 .filter-image-holder {
     width: 50px;
     height: 50px;
@@ -266,6 +271,7 @@ fieldset[disabled] .btn-size.active {
     width: 100%;
     height: 100%;
 }
+.pokemon-popup-image-holder > img,
 .filter-image-holder > img,
 .marker-image-holder > img,
 .leaflet-container .leaflet-marker-pane .marker-image-holder > img {
@@ -277,6 +283,10 @@ fieldset[disabled] .btn-size.active {
     bottom: 0;
     left: 0;
     right: 0;
+}
+.marker-image-holder.top-overlay > img,
+.leaflet-container .leaflet-marker-pane .marker-image-holder.top-overlay > img {
+    top: auto;
 }
 
 @media (max-height: 600px) {

--- a/src/views/index-css.mustache
+++ b/src/views/index-css.mustache
@@ -261,10 +261,13 @@ fieldset[disabled] .btn-size.active {
     width: 64px;
     height: 64px;
     margin: auto;
+    position: relative;
 }
 .filter-image-holder {
     width: 50px;
     height: 50px;
+    margin: auto;
+    position: relative;
 }
 .marker-image-holder {
     position: absolute;

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -1802,7 +1802,6 @@ function loadData () {
         show_submission_type_cells: showSubmissionCells && map.getZoom() >= 14,
         show_weather: showWeather,
         show_active_devices: showDevices,
-        icon_style: selectedIconStyle,
         last_update: lastUpdateServer,
         _csrf: '{{csrf}}'
     };
@@ -5364,6 +5363,18 @@ function getCpAtLevel(id, level, isMax) {
 
 // MARK: - Init Filter
 
+function populateImage (row, type, set, meta) {
+    const input = row.image;
+    switch (input.type) {
+        case 'img':
+            return `<div class="filter-image-holder"><img class="lazy_load" data-src="${availableIconStyles[selectedIconStyle].path}${input.path}"/></div>`;
+        case 'pokemon':
+            return `<div class="filter-image-holder"><img class="lazy_load" data-src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(input.pokemonId, input.form)}.png"/></div>`;
+        default:
+            return input;
+    }
+}
+
 function loadPokemonFilter () {
     const table = $('#table-filter-pokemon').DataTable({
         language: {
@@ -5382,7 +5393,7 @@ function loadPokemonFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -5481,7 +5492,7 @@ function loadQuestFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -5578,7 +5589,7 @@ function loadRaidFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -5675,7 +5686,7 @@ function loadGymFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -5772,7 +5783,7 @@ function loadPokestopFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -5869,7 +5880,7 @@ function loadInvasionFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -5966,7 +5977,7 @@ function loadSpawnpointFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -6063,7 +6074,7 @@ function loadNestFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -6160,7 +6171,7 @@ function loadWeatherFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {
@@ -6256,7 +6267,7 @@ function loadDeviceFilter () {
         },
         autoWidth: false,
         columns: [
-            { data: 'image', width: '5%', className: 'details-control' },
+            { data: populateImage, width: '5%', className: 'details-control' },
             { data: 'name', width: '15%' },
             {
                 data: {

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -290,7 +290,6 @@ $(function () {
         async: true
     });
 
-    availableForms = new Set(JSON.parse('{{{available_forms_json}}}'));
     availableItems = JSON.parse('{{{available_items_json}}}');
     availableTileservers = JSON.parse(`{{{available_tileservers_json}}}`);
     availableIconStyles = JSON.parse('{{{available_icon_styles_json}}}');
@@ -454,6 +453,7 @@ $(function () {
         selectedIconStyle = this.value;
         store('iconstyle', this.value);
 
+        buildAvailableForms();
         // TODO: Redraw markers/update icons for markers, invalidate map
     });
 
@@ -543,6 +543,10 @@ $(function () {
 
 // MARK: - Setup
 
+function buildAvailableForms () {
+    availableForms = new Set(availableIconStyles[selectedIconStyle].pokemonList);
+}
+
 function loadStorage () {
     const selectedTileserverTmp = retrieve('tileserver');
     if (selectedTileserverTmp === undefined) {
@@ -565,6 +569,7 @@ function loadStorage () {
             selectedIconStyle = selectedIconStyleTmp;
         }
     }
+    buildAvailableForms();
 
     const showGymsValue = retrieve('show_gyms');
     if (showGymsValue === null) {

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -5162,7 +5162,9 @@ function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = fa
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
     pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    return `${pokeId}_${defaultForm}${shinySuffix}`;
+    pokemonIdString = `${pokeId}_${defaultForm}${shinySuffix}`;
+    if (availableForms.has(pokemonIdString)) return pokemonIdString;
+    return '000';   // substitute
 }
 
 function getPokemonBestRank(greatLeague, ultraLeague) {

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -5141,7 +5141,7 @@ function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = fa
         pokemonIdString = `${pokeId}_${pokemonForm}${shinySuffix}`;
         if (availableForms.has(pokemonIdString)) return pokemonIdString;
     }
-    const defaultForm = masterfile.pokemon[pokemonId].default_form_id;
+    const defaultForm = (masterfile.pokemon[pokemonId] || {}).default_form_id;
     if (defaultForm) {
         let pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${costumeSuffix}${shinySuffix}`;
         if (availableForms.has(pokemonIdString)) return pokemonIdString;

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -5123,7 +5123,7 @@ function getSize (size) {
 function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = false, costumeId = 0, shiny = false) {
     const pokeId = zeroPad(pokemonId, 3);
     const costumeSuffix = costumeId ? `_${costumeId}` : '';
-    const shinySuffix = shinyId ? '_shiny' : '';
+    const shinySuffix = shiny ? '_shiny' : '';
     if (evolutionId) {
         let pokemonIdString = `${pokeId}_v${evolutionId}${costumeSuffix}${shinySuffix}`;
         if (availableForms.has(pokemonIdString)) return pokemonIdString;

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -2565,8 +2565,8 @@ function getPokemonPopupContent (pokemon) {
 
     '<div class="row">' + // START 2ND ROW
         '<div class="' + (hasIV ? 'col-6 col-md-4' : 'col text-center') + '">' +
-            '<div class="row' + (hasIV ? '' : 'text-center') + '" style="margin: auto;">' +
-                `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png" height="64" width="64">` +
+            '<div class="row pokemon-popup-image-holder">' +
+                `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png">` +
             '</div>' + // END POKEMON ROW
             '<div class="row text-nowrap" style="margin-left:auto; margin-right:auto;">';
     const pkmn = masterfile.pokemon[pokemon.pokemon_id];
@@ -2952,11 +2952,11 @@ function getGymPopupContent (gym) {
         content +=
         '<div class="row" style="margin:auto;">' + // START 1ST ROW
             '<div class="col-6 col-md-4">' + // START 1ST COL
-                '<div class="row" style="margin:auto;">';
+                '<div class="row pokemon-popup-image-holder">';
         if (hasRaidBoss && isRaidBattle) {
-            content += `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png" height="64" width="64">`;
+            content += `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png">`;
         } else {
-            content += `<img src="${availableIconStyles[selectedIconStyle].path}/egg/${gym.raid_level}.png" height="64" width="64">`;
+            content += `<img src="${availableIconStyles[selectedIconStyle].path}/egg/${gym.raid_level}.png">`;
         }
         content +=
                 '</div>' + // END POKEMON ROW
@@ -3494,19 +3494,6 @@ function getWeatherMarker (weather, ts) {
 }
 
 function getNestMarker (nest, geojson, ts) {
-    const pkmn = masterfile.pokemon[nest.pokemon_id];
-    let typesIcon = '';
-    if (pkmn !== undefined && pkmn !== null) {
-        const types = pkmn.types;
-        if (types !== null && types.length > 0) {
-            if (types.length === 2) {
-                typesIcon += `<span class="text-nowrap"><img src="${availableIconStyles[selectedIconStyle].path}/type/${types[0].toLowerCase()}.png" height="24" width="24">&nbsp;`;
-                typesIcon += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[1].toLowerCase()}.png" height="24" width="24"></span>`;
-            } else {
-                typesIcon += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[0].toLowerCase()}.png" height="24" width="24">`;
-            }
-        }
-    }
     const nestPolygonMarker = L.geoJson(geojson, {
         /*
         pointToLayer: function(feature, latlng) {
@@ -3538,7 +3525,7 @@ function getNestMarker (nest, geojson, ts) {
                 iconAnchor: [40 / 2, 40 / 2],
                 popupAnchor: [0, 40 * -.6],
                 className: 'nest-marker',
-                html: `<center><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(nest.pokemon_id)}.png" style="width:40px;height:auto; background-color:transparent;"/><br>${typesIcon}</center>`
+                html: `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(nest.pokemon_id)}.png"/></div>`
             });
             /*
             const icon = L.icon({
@@ -3587,19 +3574,19 @@ function getPokemonMarkerIcon (pokemon, ts) {
                 ? 'first'
                 : '';
     let iconHtml = bestRank <= 3 && bestRankIcon !== ''
-        ? `<img src="${availableIconStyles[selectedIconStyle].path}/misc/${bestRankIcon}.png" style="width:${size / 2}px;height:auto; background-color:transparent; padding:0; margin:-15px 0 0 15px;" />`
+        ? `<img src="${availableIconStyles[selectedIconStyle].path}/misc/${bestRankIcon}.png" style="width:${size / 2}px;height:auto;position:absolute;right:0;bottom:0;" />`
         : '';
     const icon = L.divIcon({
         iconSize: [size, size],
         iconAnchor: [size / 2, size / 2],
         popupAnchor: [0, size * -.6],
         className: 'pokemon-marker',
-        html: `<center><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIdString}.png" style="width:${size}px;height:auto; background-color:transparent; ` +
+        html: `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIdString}.png" style="` +
         (
             iv >= glowIV
             ? `filter:drop-shadow(0 0 10px ${color})drop-shadow(0 0 10px ${color});-webkit-filter:drop-shadow(0 0 10px ${color})drop-shadow(0 0 10px ${color});`
             : ''
-        ) + `"/>${iconHtml}</center>`
+        ) + `"/></div>${iconHtml}`
     });
     return icon;
 }
@@ -3671,7 +3658,7 @@ function getPokestopMarkerIcon (pokestop, ts) {
         }
         questSize = getQuestSize(rewardString);
         const offsetY = stopSize * (availableIconStyles[selectedIconStyle].questOffsetY || 0) - questSize;
-        iconHtml = `<div class="marker-image-holder" style="width:${questSize}px;height:${questSize}px;left:50%;transform:translateX(-50%);top:${offsetY}px;"><img src="${iconUrl}"/></div>`;
+        iconHtml = `<div class="marker-image-holder top-overlay" style="width:${questSize}px;height:${questSize}px;left:50%;transform:translateX(-50%);top:${offsetY}px;"><img src="${iconUrl}"/></div>`;
         popupAnchorY += offsetY;
     }
     const icon = L.divIcon({
@@ -3789,7 +3776,7 @@ function getGymMarkerIcon (gym, ts) {
     }
     if (raidSize > 0) {
         let offsetY = gymSize * (availableIconStyles[selectedIconStyle].raidOffsetY || .269) - raidSize;
-        iconHtml += `<div class="marker-image-holder" style="width:${raidSize}px;height:${raidSize}px;left:50%;transform:translateX(-50%);top:${offsetY}px;"><img src="${raidIcon}"/></div>`;
+        iconHtml += `<div class="marker-image-holder top-overlay" style="width:${raidSize}px;height:${raidSize}px;left:50%;transform:translateX(-50%);top:${offsetY}px;"><img src="${raidIcon}"/></div>`;
         popupAnchorY += offsetY;
     }
     const icon = L.divIcon({

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -3667,7 +3667,8 @@ function getPokestopMarkerIcon (pokestop, ts) {
             //iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-3.png`;
             iconUrl = `${availableIconStyles[selectedIconStyle].path}/reward/reward_1301_${info.amount}.png`;
         } else if (id === 7 && info !== undefined && info.pokemon_id !== undefined) {
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(info.pokemon_id, info.form_id)}.png`;
+            // TODO: evolution https://github.com/versx/DataParser/issues/10
+            iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(info.pokemon_id, info.form_id, 0, info.gender_id == 2, info.costume_id, info.shiny)}.png`;
         }
         questSize = getQuestSize(rewardString);
         const offsetY = stopSize * (availableIconStyles[selectedIconStyle].questOffsetY || 0) - questSize;
@@ -5133,24 +5134,25 @@ function getSize (size) {
     return 'Big';
 }
 
-function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = false, costumeId = 0) {
+function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = false, costumeId = 0, shiny = false) {
     const pokeId = zeroPad(pokemonId, 3);
     const costumeSuffix = costumeId ? `_${costumeId}` : '';
+    const shinySuffix = shinyId ? '_shiny' : '';
     if (evolutionId) {
-        let pokemonIdString = `${pokeId}_v${evolutionId}${costumeSuffix}`;
+        let pokemonIdString = `${pokeId}_v${evolutionId}${costumeSuffix}${shinySuffix}`;
         if (availableForms.has(pokemonIdString)) return pokemonIdString;
-        pokemonIdString = `${pokeId}_v${evolutionId}`;
+        pokemonIdString = `${pokeId}_v${evolutionId}${shinySuffix}`;
         if (availableForms.has(pokemonIdString)) return pokemonIdString;
     }
     const realForm = pokemonForm || masterfile.pokemon[pokemonId].default_form_id;
     const femaleSuffix = female ? '_female' : '';
-    let pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}${costumeSuffix}`;
+    let pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}${costumeSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    pokemonIdString = `${pokeId}_${realForm}${costumeSuffix}`;
+    pokemonIdString = `${pokeId}_${realForm}${costumeSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}`;
+    pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    return `${pokeId}_${realForm}`;
+    return `${pokeId}_${realForm}${shinySuffix}`;
 }
 
 function getPokemonBestRank(greatLeague, ultraLeague) {

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -5144,15 +5144,25 @@ function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = fa
         pokemonIdString = `${pokeId}_v${evolutionId}${shinySuffix}`;
         if (availableForms.has(pokemonIdString)) return pokemonIdString;
     }
-    const realForm = pokemonForm || masterfile.pokemon[pokemonId].default_form_id;
     const femaleSuffix = female ? '_female' : '';
-    let pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}${costumeSuffix}${shinySuffix}`;
+    if (pokemonForm) {
+        let pokemonIdString = `${pokeId}_${pokemonForm}${femaleSuffix}${costumeSuffix}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+        pokemonIdString = `${pokeId}_${pokemonForm}${costumeSuffix}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+        pokemonIdString = `${pokeId}_${pokemonForm}${femaleSuffix}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+        pokemonIdString = `${pokeId}_${pokemonForm}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+    }
+    const defaultForm = masterfile.pokemon[pokemonId].default_form_id;
+    let pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${costumeSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    pokemonIdString = `${pokeId}_${realForm}${costumeSuffix}${shinySuffix}`;
+    pokemonIdString = `${pokeId}_${defaultForm}${costumeSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}${shinySuffix}`;
+    pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    return `${pokeId}_${realForm}${shinySuffix}`;
+    return `${pokeId}_${defaultForm}${shinySuffix}`;
 }
 
 function getPokemonBestRank(greatLeague, ultraLeague) {

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -5142,13 +5142,23 @@ function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = fa
         if (availableForms.has(pokemonIdString)) return pokemonIdString;
     }
     const defaultForm = masterfile.pokemon[pokemonId].default_form_id;
-    let pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${costumeSuffix}${shinySuffix}`;
+    if (defaultForm) {
+        let pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${costumeSuffix}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+        pokemonIdString = `${pokeId}_${defaultForm}${costumeSuffix}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+        pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+        pokemonIdString = `${pokeId}_${defaultForm}${shinySuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+    }
+    let pokemonIdString = `${pokeId}_00${femaleSuffix}${costumeSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    pokemonIdString = `${pokeId}_${defaultForm}${costumeSuffix}${shinySuffix}`;
+    pokemonIdString = `${pokeId}_00${costumeSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    pokemonIdString = `${pokeId}_${defaultForm}${femaleSuffix}${shinySuffix}`;
+    pokemonIdString = `${pokeId}_00${femaleSuffix}${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
-    pokemonIdString = `${pokeId}_${defaultForm}${shinySuffix}`;
+    pokemonIdString = `${pokeId}_00${shinySuffix}`;
     if (availableForms.has(pokemonIdString)) return pokemonIdString;
     return '000';   // substitute
 }

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -290,7 +290,7 @@ $(function () {
         async: true
     });
 
-    availableForms = JSON.parse('{{{available_forms_json}}}');
+    availableForms = new Set(JSON.parse('{{{available_forms_json}}}'));
     availableItems = JSON.parse('{{{available_items_json}}}');
     availableTileservers = JSON.parse(`{{{available_tileservers_json}}}`);
     availableIconStyles = JSON.parse('{{{available_icon_styles_json}}}');
@@ -2546,7 +2546,8 @@ function getPokemonPopupContent (pokemon) {
         pokemonName += ' (' + getPokemonNameNoId(pokemon.display_pokemon_id) + ')';
     }
 
-    const pokemonIcon = getPokemonIcon(pokemon.pokemon_id, pokemon.form, 0);
+    // TODO: add evolution https://github.com/versx/DataParser/issues/9
+    const pokemonIcon = getPokemonIcon(pokemon.pokemon_id, pokemon.form, 0, pokemon.gender == 2, pokemon.costume);
 
     content +=
     '<div class="row">' + // START 1ST ROW
@@ -2566,7 +2567,7 @@ function getPokemonPopupContent (pokemon) {
     '<div class="row">' + // START 2ND ROW
         '<div class="' + (hasIV ? 'col-6 col-md-4' : 'col text-center') + '">' +
             '<div class="row' + (hasIV ? '' : 'text-center') + '" style="margin: auto;">' +
-                `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/${pokemonIcon}" height="64" width="64">` +
+                `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png" height="64" width="64">` +
             '</div>' + // END POKEMON ROW
             '<div class="row text-nowrap" style="margin-left:auto; margin-right:auto;">';
     const pkmn = masterfile.pokemon[pokemon.pokemon_id];
@@ -2948,13 +2949,13 @@ function getGymPopupContent (gym) {
         } else {
             pokemonName = 'Level ' + gym.raid_level + ' Egg';
         }
-        const pokemonIcon = getPokemonIcon(gym.raid_pokemon_id, gym.raid_pokemon_form, gym.raid_pokemon_evolution);
+        const pokemonIcon = getPokemonIcon(gym.raid_pokemon_id, gym.raid_pokemon_form, gym.raid_pokemon_evolution, gym.raid_pokemon_gender == 2, gym.raid_pokemon_costume);
         content +=
         '<div class="row" style="margin:auto;">' + // START 1ST ROW
             '<div class="col-6 col-md-4">' + // START 1ST COL
                 '<div class="row" style="margin:auto;">';
         if (hasRaidBoss && isRaidBattle) {
-            content += `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/${pokemonIcon}" height="64" width="64">`;
+            content += `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png" height="64" width="64">`;
         } else {
             content += `<img src="${availableIconStyles[selectedIconStyle].path}/egg/${gym.raid_level}.png" height="64" width="64">`;
         }
@@ -3538,7 +3539,7 @@ function getNestMarker (nest, geojson, ts) {
                 iconAnchor: [40 / 2, 40 / 2],
                 popupAnchor: [0, 40 * -.6],
                 className: 'nest-marker',
-                html: `<center><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/${getPokemonIcon(nest.pokemon_id, 0, 0)}" style="width:40px;height:auto; background-color:transparent;"/><br>${typesIcon}</center>`
+                html: `<center><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(nest.pokemon_id)}.png" style="width:40px;height:auto; background-color:transparent;"/><br>${typesIcon}</center>`
             });
             /*
             const icon = L.icon({
@@ -3574,7 +3575,7 @@ function calcIV(atk, def, sta) {
 
 function getPokemonMarkerIcon (pokemon, ts) {
     const size = getPokemonSize(pokemon.pokemon_id, pokemon.form);
-    const pokemonIdString = getPokemonIcon(pokemon.pokemon_id, pokemon.form, 0);
+    const pokemonIdString = getPokemonIcon(pokemon.pokemon_id, pokemon.form, 0, pokemon.gender == 2, pokemon.costume);
     const color = '{{glow_color}}';
     const glowIV = parseFloat('{{glow_iv}}');
     const iv = calcIV(pokemon.atk_iv, pokemon.def_iv, pokemon.sta_iv);
@@ -3594,7 +3595,7 @@ function getPokemonMarkerIcon (pokemon, ts) {
         iconAnchor: [size / 2, size / 2],
         popupAnchor: [0, size * -.6],
         className: 'pokemon-marker',
-        html: `<center><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/${pokemonIdString}" style="width:${size}px;height:auto; background-color:transparent; ` +
+        html: `<center><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIdString}.png" style="width:${size}px;height:auto; background-color:transparent; ` +
         (
             iv >= glowIV
             ? `filter:drop-shadow(0 0 10px ${color})drop-shadow(0 0 10px ${color});-webkit-filter:drop-shadow(0 0 10px ${color})drop-shadow(0 0 10px ${color});`
@@ -3666,16 +3667,7 @@ function getPokestopMarkerIcon (pokestop, ts) {
             //iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-3.png`;
             iconUrl = `${availableIconStyles[selectedIconStyle].path}/reward/reward_1301_${info.amount}.png`;
         } else if (id === 7 && info !== undefined && info.pokemon_id !== undefined) {
-            if (info.form_id !== 0 && info.form_id !== null) {
-                const pokemonIdStringTmp = info.pokemon_id + '-' + info.form_id;
-                if ($.inArray(pokemonIdStringTmp, availableForms) !== -1) {
-                    iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon/${getPokemonIcon(info.pokemon_id, info.form_id, 0)}`;
-                } else {
-                    iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon/${getPokemonIcon(info.pokemon_id, 0, 0)}`;
-                }
-            } else {
-                iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon/${getPokemonIcon(info.pokemon_id, 0, 0)}`;
-            }
+            iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(info.pokemon_id, info.form_id)}.png`;
         }
         questSize = getQuestSize(rewardString);
         const offsetY = stopSize * (availableIconStyles[selectedIconStyle].questOffsetY || 0) - questSize;
@@ -3784,7 +3776,7 @@ function getGymMarkerIcon (gym, ts) {
         if (gym.raid_pokemon_id !== 0 && gym.raid_pokemon_id !== null) {
             // Raid Boss
             raidSize = getRaidSize('p' + gym.raid_pokemon_id);
-            raidIcon = `${availableIconStyles[selectedIconStyle].path}/pokemon/${getPokemonIcon(gym.raid_pokemon_id, gym.raid_pokemon_form, gym.raid_pokemon_evolution)}`;
+            raidIcon = `${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(gym.raid_pokemon_id, gym.raid_pokemon_form, gym.raid_pokemon_evolution, gym.raid_pokemon_gender == 2, gym.raid_pokemon_costume)}.png`;
         } else {
             // Egg
             raidSize = getRaidSize('l' + raidLevel);
@@ -5141,22 +5133,24 @@ function getSize (size) {
     return 'Big';
 }
 
-function getPokemonIcon(pokemonId, pokemonForm, evolutionId) {
+function getPokemonIcon(pokemonId, pokemonForm = 0, evolutionId = 0, female = false, costumeId = 0) {
     const pokeId = zeroPad(pokemonId, 3);
-    let pokemonIdString = pokeId;
-    if (pokemonForm > 0 && $.inArray(pokemonId + '-' + pokemonForm, availableForms) !== -1) {
-        pokemonIdString += '_' + pokemonForm;
-    } else {
-        pokemonIdString += '_00';
+    const costumeSuffix = costumeId ? `_${costumeId}` : '';
+    if (evolutionId) {
+        let pokemonIdString = `${pokeId}_v${evolutionId}${costumeSuffix}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
+        pokemonIdString = `${pokeId}_v${evolutionId}`;
+        if (availableForms.has(pokemonIdString)) return pokemonIdString;
     }
-    if (evolutionId > 0) {
-        if ($.inArray(pokemonId + '-' + pokemonForm + '-' + evolutionId, availableForms) !== -1) {
-            pokemonIdString += '_' + evolutionId;
-        } else {
-            pokemonIdString += '';
-        }
-    }
-    return 'pokemon_icon_' + pokemonIdString + '.png';
+    const realForm = pokemonForm || masterfile.pokemon[pokemonId].default_form_id;
+    const femaleSuffix = female ? '_female' : '';
+    let pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}${costumeSuffix}`;
+    if (availableForms.has(pokemonIdString)) return pokemonIdString;
+    pokemonIdString = `${pokeId}_${realForm}${costumeSuffix}`;
+    if (availableForms.has(pokemonIdString)) return pokemonIdString;
+    pokemonIdString = `${pokeId}_${realForm}${femaleSuffix}`;
+    if (availableForms.has(pokemonIdString)) return pokemonIdString;
+    return `${pokeId}_${realForm}`;
 }
 
 function getPokemonBestRank(greatLeague, ultraLeague) {


### PR DESCRIPTION
* Uses pokemon icons from https://github.com/Mygod/pokemon-icon-postprocessor
* Proper support for form, temporary/mega evolution, male/female, costume, shiny pokemon
* Fat pokemon properly displays right above the gym/pokestop, without the extra margin
* Automagic fallback for new pokemon/form/temp evolution/costume
* Dynamic image resolution for filter menu
* Oh also adds `raid_pokemon_costume`

Needs testing.

Fixes #116.