### PR TITLE
Double check on quest reward type for quest pokemon/id

### DIFF
--- a/src/data/map.js
+++ b/src/data/map.js
@@ -517,9 +517,9 @@ const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPok
         }
 
         if (excludedPokemon.length === 0) {
-            excludePokemonSQL = 'OR (quest_pokemon_id IS NOT NULL)';
+            excludePokemonSQL = 'OR (quest_reward_type IS NOT NULL AND quest_reward_type = 7 AND quest_pokemon_id IS NOT NULL)';
         } else {
-            let sqlExcludeCreate = 'OR (quest_pokemon_id IS NOT NULL AND quest_pokemon_id NOT IN (';
+            let sqlExcludeCreate = 'OR (quest_reward_type IS NOT NULL AND quest_reward_type = 7 AND quest_pokemon_id IS NOT NULL AND quest_pokemon_id NOT IN (';
             for (let i = 0; i < excludedPokemon.length; i++) {
                 if (i === excludedPokemon.length - 1) {
                     sqlExcludeCreate += '?))';
@@ -533,9 +533,9 @@ const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPok
         }
 
         if (excludedItems.length === 0) {
-            excludeItemSQL = 'OR (quest_item_id IS NOT NULL)';
+            excludeItemSQL = 'OR (quest_reward_type IS NOT NULL AND quest_reward_type = 3 AND quest_item_id IS NOT NULL)';
         } else {
-            let sqlExcludeCreate = 'OR ((quest_item_id IS NOT NULL AND quest_item_id NOT IN (';
+            let sqlExcludeCreate = 'OR (quest_reward_type IS NOT NULL AND quest_reward_type = 3 AND quest_item_id IS NOT NULL AND quest_item_id NOT IN (';
             for (let i = 0; i < excludedItems.length; i++) {
                 if (i === excludedItems.length - 1) {
                     sqlExcludeCreate += '?))';

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -535,17 +535,15 @@ const getPokestops = async (minLat, maxLat, minLon, maxLon, updated = 0, showPok
         if (excludedItems.length === 0) {
             excludeItemSQL = 'OR (quest_reward_type IS NOT NULL AND quest_reward_type = 3 AND quest_item_id IS NOT NULL)';
         } else {
-            let sqlExcludeCreate = 'OR (quest_reward_type IS NOT NULL AND quest_reward_type = 3 AND quest_item_id IS NOT NULL AND quest_item_id NOT IN (';
+            excludeItemSQL = 'OR (quest_reward_type IS NOT NULL AND quest_reward_type = 3 AND quest_item_id IS NOT NULL AND quest_item_id NOT IN (';
             for (let i = 0; i < excludedItems.length; i++) {
                 if (i === excludedItems.length - 1) {
-                    sqlExcludeCreate += '?))';
+                    excludeItemSQL += '?)';
                 } else {
-                    sqlExcludeCreate += '?, ';
+                    excludeItemSQL += '?, ';
                 }
                 args.push(excludedItems[i]);
             }
-            excludeItemSQL = sqlExcludeCreate;
-
             if (minimumCandyCount > 0) {
                 excludeItemSQL += ' AND (quest_item_id <> 1301 OR JSON_VALUE(quest_rewards, "$[0].info.amount") >= ?)';
                 args.push(minimumCandyCount);


### PR DESCRIPTION
Fix candy/mega resource not filtered out unless pokemon is also excluded.

~~Also fix an extra `(`. Oops.~~ Double oops.

Maybe we should have filtering candy/mega resources per pokemon in the future? One way to implement this is to use a single list and allow user to enable/disable {encounter, candy, mega resources}.