### PR TITLE
fix: Remove pokestop & invasion cluster markers

### DIFF
--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -1160,13 +1160,21 @@ function initMap () {
         }
         if (newShowInvasions !== showInvasions && newShowInvasions === false) {
             $.each(pokestopMarkers, function (index, pokestop) {
-                map.removeLayer(pokestop.marker);
+                if (clusterPokestops) {
+                    clusters.removeLayer(pokestop.marker);
+                } else {
+                    map.removeLayer(pokestop.marker);
+                }
             });
             pokestopMarkers = [];
         }
         if (newShowQuests !== showQuests) {
             $.each(pokestopMarkers, function (index, pokestop) {
-                map.removeLayer(pokestop.marker);
+                if (clusterPokestops) {
+                    clusters.removeLayer(pokestop.marker);
+                } else {
+                    map.removeLayer(pokestop.marker);
+                }
             });
             pokestopMarkers = [];
         }


### PR DESCRIPTION
Managed to miss this in #130

Fix: #134 