### PR TITLE
Only Support Custom Pokemon icons in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,19 +259,10 @@ NodeJS Map clone replacement for [RealDeviceMap](https://github.com/realdevicema
     "icons": {
         // Default local icon repository
         "Default": {
-            "path": "/img/",
-            "raidOffsetY": 0.269,
-            "questOffsetY": 0,
-            "gymAnchorY": 0.849,
-            "pokestopAnchorY": 0.896
+            "path": "/img"
         },
-        "RemotePokemonExample": {
-            "path": "https://example.com/pokemon_images",
-            "pokemonList": ["001_163", "002_166", "002_166_shiny", "003_169", "003_169_female"],
-            "raidOffsetY": 0.269,
-            "questOffsetY": 0,
-            "gymAnchorY": 0.849,
-            "pokestopAnchorY": 0.896
+        "POGO": {
+            "path": "https://raw.githubusercontent.com/Mygod/pokicons/master/v1"
         }
     },
     // Scouting settings

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ NodeJS Map clone replacement for [RealDeviceMap](https://github.com/realdevicema
             // expected format is <xxx pokemon id>(_00|_<form id>|_v<temp evolution id>)[_female][_<xx costume id>][_shiny]
             // automatic fallback is in place, so the bare minimum you need to provide is "xxx_00" for each pokemon
             // and "000" for new pokemon fallback (000 does not need to appear in pokemonList)
+	    // Reference: Asset icon processing tool: https://github.com/Mygod/pokemon-icon-postprocessor
         }
     },
     // Scouting settings

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -160,7 +160,7 @@
     },
     "icons": {
         "Default": {
-            "path": "/img"
+            "path": "/img/pokemon"
         },
         "POGO": {
             "path": "https://mygod.github.io/pokicons/v1"

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -159,21 +159,8 @@
         "adsense": ""
     },
     "icons": {
-        "Default": {
-            "path": "/img",
-            "raidOffsetY": 0.269,
-            "questOffsetY": 0,
-            "gymAnchorY": 0.849,
-            "pokestopAnchorY": 0.896
-        },
-        "RemotePokemonExample": {
-            "path": "https://example.com/pokemon_images",
-            "pokemonList": ["001_163", "002_166", "002_166_shiny", "003_169", "003_169_female"],
-            "raidOffsetY": 0.269,
-            "questOffsetY": 0,
-            "gymAnchorY": 0.849,
-            "pokestopAnchorY": 0.896
-        }
+        "Default": "/img/pokemon",
+        "POGO": "https://raw.githubusercontent.com/Mygod/pokicons/master/v1"
     },
     "scouting": {
         "enabled": false,

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -159,8 +159,12 @@
         "adsense": ""
     },
     "icons": {
-        "Default": "/img/pokemon",
-        "POGO": "https://raw.githubusercontent.com/Mygod/pokicons/master/v1"
+        "Default": {
+            "path": "/img"
+        },
+        "POGO": {
+            "path": "https://raw.githubusercontent.com/Mygod/pokicons/master/v1"
+        }
     },
     "scouting": {
         "enabled": false,

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1058,7 +1058,7 @@ const getNests = async (minLat, maxLat, minLon, maxLon, nestFilterExclude = null
     return null;
 };
 
-const getSearchData = async (lat, lon, id, value) => {
+const getSearchData = async (lat, lon, id, value, iconStyle) => {
     let sql = '';
     let args = [lat, lon, lat];
     let useManualDb = false;
@@ -1187,19 +1187,19 @@ const getSearchData = async (lat, lon, id, value) => {
                     let result = results[i];
                     // TODO: Check quest types
                     if (result.quest_item_id > 0) {
-                        result.url2 = config.icons['Default'/* TODO: Add icon style */].path + `/item/${result.quest_item_id}.png`;
+                        result.url2 = `/img/item/${result.quest_item_id}.png`;
                     } else if (result.quest_pokemon_id > 0) {
                         const formId = result.quest_pokemon_form_id > 0 ? result.quest_pokemon_form_id : '00';
-                        result.url2 = config.icons['Default'/* TODO: Add icon style */].path + `/pokemon/pokemon_icon_${utils.zeroPad(result.quest_pokemon_id, 3)}_${formId}.png`;
+                        result.url2 = config.icons[iconStyle].path + `/pokemon_icon_${utils.zeroPad(result.quest_pokemon_id, 3)}_${formId}.png`;
                     } else if (result.quest_reward_type === 3) {
-                        result.url2 = config.icons['Default'/* TODO: Add icon style */].path + '/item/-1.png';
+                        result.url2 = '/item/-1.png';
                     }
                 }
                 break;
             case 'search-nest':
                 for (let i = 0; i < results.length; i++) {
                     let result = results[i];
-                    result.url = config.icons['Default'/* TODO: Add icon style */].path + `/pokemon/pokemon_icon_${utils.zeroPad(result.pokemon_id, 3)}_00.png`;
+                    result.url = config.icons[iconStyle].path + `/pokemon_icon_${utils.zeroPad(result.pokemon_id, 3)}_00.png`;
                 }
                 break;
         }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -798,7 +798,7 @@ const getData = async (perms, filter) => {
 };
 
 const getSearch = async (filter) => {
-    const searchData = await map.getSearchData(filter.lat, filter.lon, filter.id, filter.value);
+    const searchData = await map.getSearchData(filter.lat, filter.lon, filter.id, filter.value, filter.icon_style);
     return searchData;
 };
 

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -340,13 +340,13 @@ $(function () {
     }
 
     deviceOnlineIcon = L.icon({
-        iconUrl: availableIconStyles[selectedIconStyle].path + '/device/0.png',
+        iconUrl: '/img/device/0.png',
         iconSize: [30, 30],
         iconAnchor: [30 / 2, 30 / 2],
         popupAnchor: [0, 30 * -.6]
     });
     deviceOfflineIcon = L.icon({
-        iconUrl: availableIconStyles[selectedIconStyle].path + '/device/1.png',
+        iconUrl: '/img/device/1.png',
         iconSize: [30, 30],
         iconAnchor: [30 / 2, 30 / 2],
         popupAnchor: [0, 30 * -.6]
@@ -1572,6 +1572,7 @@ function loadSearchData (id, value) {
             value: value,
             lat: center.lat,
             lon: center.lng,
+            icon_style: selectedIconStyle,
             _csrf: '{{csrf}}'
         },
         timeout: 30000,
@@ -2212,7 +2213,7 @@ function loadData () {
                         weather.marker = getWeatherMarker(weather, ts);
                         let weatherIcon;
                         if (weather.gameplay_condition > 0) {
-                            weatherIcon = `<img src="${availableIconStyles[selectedIconStyle].path}/weather/${weather.gameplay_condition}.png" height="25" width="25">`;
+                            weatherIcon = `<img src="/img/weather/${weather.gameplay_condition}.png" height="25" width="25">`;
                         } else {
                             weatherIcon = '';
                         }
@@ -2596,7 +2597,7 @@ function getPokemonPopupContent (pokemon) {
         '<div class="col-6 col-md-4 center-vertical">' +
             '<div style="float:right; margin-right:5px;">';
     if (!(pokemon.display_pokemon_id > 0) && pokemon.weather !== 0 && pokemon.weather !== null) {
-        content += `<img src="${availableIconStyles[selectedIconStyle].path}/weather/${pokemon.weather}.png" height="32" width="32">`;
+        content += `<img src="/img/weather/${pokemon.weather}.png" height="32" width="32">`;
     }
     content +=
             '</div>' +
@@ -2606,7 +2607,7 @@ function getPokemonPopupContent (pokemon) {
     '<div class="row">' + // START 2ND ROW
         '<div class="' + (hasIV ? 'col-6 col-md-4' : 'col text-center') + '">' +
             '<div class="row pokemon-popup-image-holder">' +
-                `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png">` +
+                `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon_icon_${pokemonIcon}.png">` +
             '</div>' + // END POKEMON ROW
             '<div class="row text-nowrap" style="margin-left:auto; margin-right:auto;">';
     const pkmn = masterfile.pokemon[pokemon.pokemon_id];
@@ -2615,10 +2616,10 @@ function getPokemonPopupContent (pokemon) {
         if (types !== null && types.length > 0) {
             content += '<div class="col">';
             if (types.length === 2) {
-                content += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[0].toLowerCase()}.png" height="16" width="16">&nbsp;`;
-                content += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[1].toLowerCase()}.png" height="16" width="16">`;
+                content += `<img src="/img/type/${types[0].toLowerCase()}.png" height="16" width="16">&nbsp;`;
+                content += `<img src="/img/type/${types[1].toLowerCase()}.png" height="16" width="16">`;
             } else {
-                content += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[0].toLowerCase()}.png" height="16" width="16">`;
+                content += `<img src="/img/type/${types[0].toLowerCase()}.png" height="16" width="16">`;
             }
             content += '</div>';
         }
@@ -2650,9 +2651,9 @@ function getPokemonPopupContent (pokemon) {
     }
     if (pokemon.capture_1 !== null && pokemon.capture_2 !== null && pokemon.capture_3 !== null) {
         content += '<b>Catch Chances:</b><br>'
-        content += `<img src="${availableIconStyles[selectedIconStyle].path}/item/1.png" height="14" width="14"> ${(pokemon.capture_1 * 100).toFixed(1)}% `
-        content += `<img src="${availableIconStyles[selectedIconStyle].path}/item/2.png" height="14" width="14"> ${(pokemon.capture_2 * 100).toFixed(1)}%<br>`
-        content += `<img src="${availableIconStyles[selectedIconStyle].path}/item/3.png" height="14" width="14"> ${(pokemon.capture_3 * 100).toFixed(1)}%<br>`
+        content += `<img src="/img/item/1.png" height="14" width="14"> ${(pokemon.capture_1 * 100).toFixed(1)}% `
+        content += `<img src="/img/item/2.png" height="14" width="14"> ${(pokemon.capture_2 * 100).toFixed(1)}%<br>`
+        content += `<img src="/img/item/3.png" height="14" width="14"> ${(pokemon.capture_3 * 100).toFixed(1)}%<br>`
     }
     content +=
         '</div>' +
@@ -2743,17 +2744,17 @@ function getPokemonPopupContent (pokemon) {
         '<div class="row">' +
             '<div class="col">' +
                 '<a href="https://www.google.com/maps/place/' + pokemon.lat + ',' + pokemon.lon + '" title="Open in Google Maps">' +
-                    `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/gmaps.png" height="32" width="32">` +
+                    `<img src="/img/navigation/gmaps.png" height="32" width="32">` +
                 '</a>' +
             '</div>' +
             '<div class="col">' +
                 '<a href="https://maps.apple.com/maps?daddr=' + pokemon.lat + ',' + pokemon.lon + '" title="Open in Apple Maps">' +
-                    `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/applemaps.png" height="32" width="32">` +
+                    `<img src="/img/navigation/applemaps.png" height="32" width="32">` +
                 '</a>' +
             '</div>' +
             '<div class="col">' +
                 '<a href="https://www.waze.com/ul?ll=' + pokemon.lat + ',' + pokemon.lon + '&navigate=yes" title="Open in Waze">' +
-                    `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/othermaps.png" height="32" width="32">` +
+                    `<img src="/img/navigation/othermaps.png" height="32" width="32">` +
                 '</a>' +
             '</div>' +
         '</div>' +
@@ -2916,17 +2917,17 @@ function getPokestopPopupContent (pokestop) {
             '<br>' +
             '<div class="col">' +
                 '<a href="https://www.google.com/maps/place/' + pokestop.lat + ',' + pokestop.lon + '" title="Open in Google Maps">' +
-                    `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/gmaps.png" height="32" width="32">` +
+                    `<img src="/img/navigation/gmaps.png" height="32" width="32">` +
                 '</a>' +
             '</div>' +
             '<div class="col">' +
                 '<a href="https://maps.apple.com/maps?daddr=' + pokestop.lat + ',' + pokestop.lon + '" title="Open in Apple Maps">' +
-                    `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/applemaps.png" height="32" width="32">` +
+                    `<img src="/img/navigation/applemaps.png" height="32" width="32">` +
                 '</a>' +
             '</div>' +
             '<div class="col">' +
                 '<a href="https://www.waze.com/ul?ll=' + pokestop.lat + ',' + pokestop.lon + '&navigate=yes" title="Open in Waze">' +
-                    `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/othermaps.png" height="32" width="32">` +
+                    `<img src="/img/navigation/othermaps.png" height="32" width="32">` +
                 '</a>' +
             '</div>' +
         '</div>' +
@@ -2968,7 +2969,7 @@ function getGymPopupContent (gym) {
         '</div>' +
         '<div class="col-6 col-md-4 center-vertical">' +
             '<div style="float:right; margin: auto;">' +
-                `<img src="${availableIconStyles[selectedIconStyle].path}/team/${gym.team_id}.png" height="32" width="32">` +
+                `<img src="/img/team/${gym.team_id}.png" height="32" width="32">` +
             '</div>' +
         '</div>' +
     '</div>'; // END 1ST ROW
@@ -2994,9 +2995,9 @@ function getGymPopupContent (gym) {
             '<div class="col-6 col-md-4">' + // START 1ST COL
                 '<div class="row pokemon-popup-image-holder">';
         if (hasRaidBoss && isRaidBattle) {
-            content += `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIcon}.png">`;
+            content += `<img src="${availableIconStyles[selectedIconStyle].path}/pokemon_icon_${pokemonIcon}.png">`;
         } else {
-            content += `<img src="${availableIconStyles[selectedIconStyle].path}/egg/${gym.raid_level}.png">`;
+            content += `<img src="/img/egg/${gym.raid_level}.png">`;
         }
         content +=
                 '</div>' + // END POKEMON ROW
@@ -3008,10 +3009,10 @@ function getGymPopupContent (gym) {
                 if (types !== null && types.length > 0) {
                     content += '<div class="col text-nowrap">';
                     if (types.length === 2) {
-                        content += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[0].toLowerCase()}.png" height="16" width="16">&nbsp;`;
-                        content += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[1].toLowerCase()}.png" height="16" width="16">`;
+                        content += `<img src="/img/type/${types[0].toLowerCase()}.png" height="16" width="16">&nbsp;`;
+                        content += `<img src="/img/type/${types[1].toLowerCase()}.png" height="16" width="16">`;
                     } else {
-                        content += `<img src="${availableIconStyles[selectedIconStyle].path}/type/${types[0].toLowerCase()}.png" height="16" width="16">`;
+                        content += `<img src="/img/type/${types[0].toLowerCase()}.png" height="16" width="16">`;
                     }
                     content += '</div>';
                 }
@@ -3055,7 +3056,7 @@ function getGymPopupContent (gym) {
             }
         }
         if (gym.ex_raid_eligible) {
-            content += `<img src="${availableIconStyles[selectedIconStyle].path}/misc/ex.png" height="24" width="32">`;
+            content += `<img src="/img/misc/ex.png" height="24" width="32">`;
         }
         content +=
             '</div>' + // END 2ND COL
@@ -3097,7 +3098,7 @@ function getGymPopupContent (gym) {
         }
         if (gym.ex_raid_eligible) {
             // content += '<b>Gym is EX-Raid eligible</b>';
-            content += `<img src="${availableIconStyles[selectedIconStyle].path}/misc/ex.png" height="24" width="32">`;
+            content += `<img src="/img/misc/ex.png" height="24" width="32">`;
         }
         content +=
             '</div>' + // END 2ND COL
@@ -3132,17 +3133,17 @@ function getGymPopupContent (gym) {
     '<div class="row text-center">' +
         '<div class="col">' +
             '<a href="https://www.google.com/maps/place/' + gym.lat + ',' + gym.lon + '" title="Open in Google Maps">' +
-                `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/gmaps.png" height="32" width="32">` +
+                `<img src="/img/navigation/gmaps.png" height="32" width="32">` +
             '</a>' +
         '</div>' +
         '<div class="col">' +
             '<a href="https://maps.apple.com/maps?daddr=' + gym.lat + ',' + gym.lon + '" title="Open in Apple Maps">' +
-                `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/applemaps.png" height="32" width="32">` +
+                `<img src="/img/navigation/applemaps.png" height="32" width="32">` +
             '</a>' +
         '</div>' +
         '<div class="col">' +
             '<a href="https://www.waze.com/ul?ll=' + gym.lat + ',' + gym.lon + '&navigate=yes" title="Open in Waze">' +
-                `<img src="${availableIconStyles[selectedIconStyle].path}/navigation/othermaps.png" height="32" width="32">` +
+                `<img src="/img/navigation/othermaps.png" height="32" width="32">` +
             '</a>' +
         '</div>' +
     '</div>';
@@ -3561,7 +3562,7 @@ function getNestMarker (nest, geojson, ts) {
                 iconAnchor: [40 / 2, 40 / 2],
                 popupAnchor: [0, 40 * -.6],
                 className: 'nest-marker',
-                html: `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(nest.pokemon_id)}.png"/></div>`
+                html: `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/pokemon_icon_${getPokemonIcon(nest.pokemon_id)}.png"/></div>`
             });
             /*
             const icon = L.icon({
@@ -3610,14 +3611,14 @@ function getPokemonMarkerIcon (pokemon, ts) {
                 ? 'first'
                 : '';
     let iconHtml = bestRank <= 3 && bestRankIcon !== ''
-        ? `<img src="${availableIconStyles[selectedIconStyle].path}/misc/${bestRankIcon}.png" style="width:${size / 2}px;height:auto;position:absolute;right:0;bottom:0;" />`
+        ? `<img src="/img/misc/${bestRankIcon}.png" style="width:${size / 2}px;height:auto;position:absolute;right:0;bottom:0;" />`
         : '';
     const icon = L.divIcon({
         iconSize: [size, size],
         iconAnchor: [size / 2, size / 2],
         popupAnchor: [0, size * -.6],
         className: 'pokemon-marker',
-        html: `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${pokemonIdString}.png" style="` +
+        html: `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/pokemon_icon_${pokemonIdString}.png" style="` +
         (
             iv >= glowIV
             ? `filter:drop-shadow(0 0 10px ${color})drop-shadow(0 0 10px ${color});-webkit-filter:drop-shadow(0 0 10px ${color})drop-shadow(0 0 10px ${color});`
@@ -3665,7 +3666,7 @@ function getPokestopMarkerIcon (pokestop, ts) {
         sizeId = lureIconId;
     }
     const stopSize = getPokestopSize(sizeId);
-    const iconAnchorY = stopSize * availableIconStyles[selectedIconStyle].pokestopAnchorY;
+    const iconAnchorY = stopSize * .896; //availableIconStyles[selectedIconStyle].pokestopAnchorY;
     let popupAnchorY = -8 - iconAnchorY;
     if (showQuests && pokestop.quest_type !== null && pokestop.quest_rewards[0] !== undefined) {
         const id = pokestop.quest_rewards[0].type;
@@ -3674,42 +3675,43 @@ function getPokestopMarkerIcon (pokestop, ts) {
         let iconUrl;
         if (id === 1 && info !== undefined && info.amount !== undefined) {
             // XP
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-2.png`;
+            iconUrl = `/img/item/-2.png`;
         } else if (id === 2 && info !== undefined && info.amount !== undefined && info.item_id !== undefined) {
             // Item
             //iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/${info.item_id}.png`;
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/reward/reward_${info.item_id}_${info.amount}.png`;
+            iconUrl = `/img/reward/reward_${info.item_id}_${info.amount}.png`;
         } else if (id === 3 && info !== undefined && info.amount !== undefined) {
             // Stardust
             //iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-1.png`;
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/reward/reward_stardust${info.amount > 0 ? '_' + info.amount : ''}.png`;
+            iconUrl = `/img/reward/reward_stardust${info.amount > 0 ? '_' + info.amount : ''}.png`;
         } else if (id === 4 && info !== undefined && info.amount !== undefined && info.pokemon_id !== undefined) {
             // Candy
             //iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-3.png`;
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/reward/reward_1301_${info.amount}.png`;
+            iconUrl = `/img/reward/reward_1301_${info.amount}.png`;
         } else if (id === 5) {
             // Avatar clothing
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-4.png`;
+            iconUrl = `/img/item/-4.png`;
         } else if (id === 6) {
             // Quest
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-5.png`;
+            iconUrl = `/img/item/-5.png`;
         } else if (id === 7 && info !== undefined) {
             // TODO: evolution https://github.com/versx/DataParser/issues/10
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(info.pokemon_id, info.form_id, 0, info.gender_id == 2, info.costume_id, info.shiny)}.png`;
+            iconUrl = `${availableIconStyles[selectedIconStyle].path}/pokemon_icon_${getPokemonIcon(info.pokemon_id, info.form_id, 0, info.gender_id == 2, info.costume_id, info.shiny)}.png`;
         } else if (id === 8) {
             // Pokecoin
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-6.png`;
+            iconUrl = `/img/item/-6.png`;
         } else if (id === 11) {
             // Sticker
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-7.png`;
+            iconUrl = `/img/item/-7.png`;
         } else if (id === 12) {
             // Mega resource
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-8.png`;
+            iconUrl = `/img/item/-8.png`;
         } else {
-            iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-0.png`;
+            iconUrl = `/img/item/-0.png`;
         }
         questSize = getQuestSize(rewardString);
-        const offsetY = stopSize * (availableIconStyles[selectedIconStyle].questOffsetY || 0) - questSize;
+        //const offsetY = stopSize * (availableIconStyles[selectedIconStyle].questOffsetY || 0) - questSize;
+        const offsetY = stopSize * 0 - questSize;
         iconHtml = `<div class="marker-image-holder top-overlay" style="width:${questSize}px;height:${questSize}px;left:50%;transform:translateX(-50%);top:${offsetY}px;"><img src="${iconUrl}"/></div>`;
         popupAnchorY += offsetY;
     }
@@ -3719,8 +3721,8 @@ function getPokestopMarkerIcon (pokestop, ts) {
         popupAnchor: [0, popupAnchorY],
         className: 'pokestop-marker',
         html: activeInvasion
-            ? `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/invasion/${sizeId}_${pokestop.grunt_type}.png"/></div>${iconHtml}`
-            : `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/pokestop/${sizeId}.png"/></div>${iconHtml}`
+            ? `<div class="marker-image-holder"><img src="/img/invasion/${sizeId}_${pokestop.grunt_type}.png"/></div>${iconHtml}`
+            : `<div class="marker-image-holder"><img src="/img/pokestop/${sizeId}.png"/></div>${iconHtml}`
     });
     return icon;
 }
@@ -3794,13 +3796,13 @@ function getGymMarkerIcon (gym, ts) {
     if (gym.in_battle) {
         // Gym Battle
         gymSize = 55; //Set Larger Size For Battle
-        iconHtml = `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/battle/${gym.team_id}_${size}.png"/></div>`;
+        iconHtml = `<div class="marker-image-holder"><img src="/img/battle/${gym.team_id}_${size}.png"/></div>`;
     } else {
         // Gym
         gymSize = getGymSize(gym.team_id);
-        iconHtml = `<div class="marker-image-holder"><img src="${availableIconStyles[selectedIconStyle].path}/gym/${gym.team_id}_${size}.png"/></div>`;
+        iconHtml = `<div class="marker-image-holder"><img src="/img/gym/${gym.team_id}_${size}.png"/></div>`;
     }
-    const iconAnchorY = gymSize * availableIconStyles[selectedIconStyle].gymAnchorY;
+    const iconAnchorY = gymSize * .849; //availableIconStyles[selectedIconStyle].gymAnchorY;
     let popupAnchorY = -8 - iconAnchorY;
 
     // Raid overlay
@@ -3811,19 +3813,20 @@ function getGymMarkerIcon (gym, ts) {
         if (gym.raid_pokemon_id !== 0 && gym.raid_pokemon_id !== null) {
             // Raid Boss
             raidSize = getRaidSize('p' + gym.raid_pokemon_id);
-            raidIcon = `${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(gym.raid_pokemon_id, gym.raid_pokemon_form, gym.raid_pokemon_evolution, gym.raid_pokemon_gender == 2, gym.raid_pokemon_costume)}.png`;
+            raidIcon = `${availableIconStyles[selectedIconStyle].path}/pokemon_icon_${getPokemonIcon(gym.raid_pokemon_id, gym.raid_pokemon_form, gym.raid_pokemon_evolution, gym.raid_pokemon_gender == 2, gym.raid_pokemon_costume)}.png`;
         } else {
             // Egg
             raidSize = getRaidSize('l' + raidLevel);
-            raidIcon = `${availableIconStyles[selectedIconStyle].path}/unknown_egg/${raidLevel}.png`;
+            raidIcon = `/img/unknown_egg/${raidLevel}.png`;
         }
     } else if (gym.raid_end_timestamp >= ts && parseInt(gym.raid_level) > 0 && showRaids) {
         // Egg
         raidSize = getRaidSize('l' + raidLevel);
-        raidIcon = `${availableIconStyles[selectedIconStyle].path}/egg/${raidLevel}.png`;
+        raidIcon = `/img/egg/${raidLevel}.png`;
     }
     if (raidSize > 0) {
-        let offsetY = gymSize * (availableIconStyles[selectedIconStyle].raidOffsetY || .269) - raidSize;
+        //let offsetY = gymSize * (availableIconStyles[selectedIconStyle].raidOffsetY || .269) - raidSize;
+        let offsetY = gymSize * .269 - raidSize;
         iconHtml += `<div class="marker-image-holder top-overlay" style="width:${raidSize}px;height:${raidSize}px;left:50%;transform:translateX(-50%);top:${offsetY}px;"><img src="${raidIcon}"/></div>`;
         popupAnchorY += offsetY;
     }
@@ -5410,9 +5413,9 @@ function populateImage (row, type, set, meta) {
     const input = row.image;
     switch (input.type) {
         case 'img':
-            return `<div class="filter-image-holder"><img class="lazy_load" data-src="${availableIconStyles[selectedIconStyle].path}${input.path}"/></div>`;
+            return `<div class="filter-image-holder"><img class="lazy_load" data-src="/img/${input.path}"/></div>`;
         case 'pokemon':
-            return `<div class="filter-image-holder"><img class="lazy_load" data-src="${availableIconStyles[selectedIconStyle].path}/pokemon/pokemon_icon_${getPokemonIcon(input.pokemonId, input.form)}.png"/></div>`;
+            return `<div class="filter-image-holder"><img class="lazy_load" data-src="${availableIconStyles[selectedIconStyle].path}/pokemon_icon_${getPokemonIcon(input.pokemonId, input.form)}.png"/></div>`;
         default:
             return input;
     }


### PR DESCRIPTION
Removes the need to create new icon repositories. Only allows for custom Pokemon icons via the config for remote and local repos.

Remote repositories are expected to look like the following with an `index.json` to depict the available form icons:  
https://github.com/Mygod/pokicons/tree/master/v1
`index.json` example:  
https://raw.githubusercontent.com/Mygod/pokicons/master/v1/index.json

Config example:
![image](https://user-images.githubusercontent.com/1327440/92299568-38cda700-ef08-11ea-9c2f-23ef22cfe3f7.png)
