### PR TITLE
Config default timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ NodeJS Map clone replacement for [RealDeviceMap](https://github.com/realdevicema
             "gyms": true,
             // Show raids
             "raids": false,
+            "raidTimers": false,
             // Show pokestops
             "pokestops": false,
             // Show quests
             "quests": false,
             // Show invasions
             "invasions": false,
+            "invasionTimers": false,
             // Show spawnpoints
             "spawnpoints": false,
             // Show Pokemon

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -22,9 +22,11 @@
         "filters": {
             "gyms": true,
             "raids": false,
+            "raidTimers": false,
             "pokestops": false,
             "quests": false,
             "invasions": false,
+            "invasionTimers": false,
             "spawnpoints": false,
             "pokemon": false,
             "nests": false,

--- a/src/data/default.js
+++ b/src/data/default.js
@@ -23,16 +23,18 @@ data.glow_iv = config.map.glow.iv;
 // Default filter options for new users/cache clears
 data.default_show_pokemon = config.map.filters.pokemon;
 data.default_show_raids = config.map.filters.raids;
+data.default_show_raidTimers = config.map.filters.raidTimers;
 data.default_show_gyms = config.map.filters.gyms;
 data.default_show_pokestops = config.map.filters.pokestops;
 data.default_show_quests = config.map.filters.quests;
 data.default_show_invasions = config.map.filters.invasions;
+data.default_show_invasionTimers = config.map.filters.invasionTimers;
 data.default_show_spawnpoints = config.map.filters.spawnpoints;
 data.default_show_weather = config.map.filters.weather;
-data.default_show_scancells = config.map.filters.scanCells;
-data.default_show_submissioncells = config.map.filters.submissionCells;
+data.default_show_scanCells = config.map.filters.scanCells;
+data.default_show_submissionCells = config.map.filters.submissionCells;
 data.default_show_nests = config.map.filters.nests;
-data.default_show_scanareas = config.map.filters.scanAreas;
+data.default_show_scanAreas = config.map.filters.scanAreas;
 data.default_show_devices = config.map.filters.devices;
 data.pokemon_rarity_json = JSON.stringify(rarity);
 

--- a/src/data/default.js
+++ b/src/data/default.js
@@ -23,18 +23,18 @@ data.glow_iv = config.map.glow.iv;
 // Default filter options for new users/cache clears
 data.default_show_pokemon = config.map.filters.pokemon;
 data.default_show_raids = config.map.filters.raids;
-data.default_show_raidTimers = config.map.filters.raidTimers;
+data.default_show_raid_timers = config.map.filters.raidTimers;
 data.default_show_gyms = config.map.filters.gyms;
 data.default_show_pokestops = config.map.filters.pokestops;
 data.default_show_quests = config.map.filters.quests;
 data.default_show_invasions = config.map.filters.invasions;
-data.default_show_invasionTimers = config.map.filters.invasionTimers;
+data.default_show_invasion_timers = config.map.filters.invasionTimers;
 data.default_show_spawnpoints = config.map.filters.spawnpoints;
 data.default_show_weather = config.map.filters.weather;
-data.default_show_scanCells = config.map.filters.scanCells;
-data.default_show_submissionCells = config.map.filters.submissionCells;
+data.default_show_scan_cells = config.map.filters.scanCells;
+data.default_show_submission_cells = config.map.filters.submissionCells;
 data.default_show_nests = config.map.filters.nests;
-data.default_show_scanAreas = config.map.filters.scanAreas;
+data.default_show_scan_areas = config.map.filters.scanAreas;
 data.default_show_devices = config.map.filters.devices;
 data.pokemon_rarity_json = JSON.stringify(rarity);
 

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -127,16 +127,18 @@ let skipForms = ['Shadow', 'Purified'];
 
 let defaultShowPokemon = '{{default_show_pokemon}}' === 'true';
 let defaultShowRaids = '{{default_show_raids}}' === 'true';
+let defaultShowRaidTimers = '{{default_show_raidTimers}}' === 'true';
 let defaultShowGyms = '{{default_show_gyms}}' === 'true';
 let defaultShowPokestops = '{{default_show_pokestops}}' === 'true';
 let defaultShowQuests = '{{default_show_quests}}' === 'true';
 let defaultShowInvasions = '{{default_show_invasions}}' === 'true';
+let defaultShowInvasionTimers = '{{default_show_invasionTimers}}' === 'true';
 let defaultShowSpawnpoints = '{{default_show_spawnpoints}}' === 'true';
 let defaultShowWeather = '{{default_show_weather}}' === 'true';
-let defaultShowScanCells = '{{default_show_scancells}}' === 'true';
-let defaultShowSubmissionCells = '{{default_show_submissioncells}}' === 'true';
+let defaultShowScanCells = '{{default_show_scanCells}}' === 'true';
+let defaultShowSubmissionCells = '{{default_show_submissionCells}}' === 'true';
 let defaultShowNests = '{{default_show_nests}}' === 'true';
-let defaultShowScanAreas = '{{default_show_scanareas}}' === 'true';
+let defaultShowScanAreas = '{{default_show_scanAreas}}' === 'true';
 let defaultShowDevices = '{{default_show_devices}}' === 'true';
 
 const pokemonRarity = JSON.parse('{{{pokemon_rarity_json}}}');
@@ -589,6 +591,14 @@ function loadStorage () {
         showRaids = (showRaidsValue === 'true');
     }
 
+    const showRaidTimersValue = retrieve('show_raid_timers');
+    if (showRaidTimersValue === null) {
+        store('show_raid_timers', defaultShowRaidTimers);
+        showRaidTimers = defaultShowRaidTimers;
+    } else {
+        showRaidTimers = (showRaidTimersValue === 'true');
+    }
+
     const showPokestopsValue = retrieve('show_pokestops');
     if (showPokestopsValue === null) {
         store('show_pokestops', defaultShowPokestops);
@@ -611,6 +621,14 @@ function loadStorage () {
         showInvasions = defaultShowInvasions;
     } else {
         showInvasions = (showInvasionsValue === 'true');
+    }
+
+    const showInvasionTimersValue = retrieve('show_invasion_timers');
+    if (showInvasionTimersValue === null) {
+        store('show_invasion_timers', defaultShowInvasionTimers);
+        showInvasionTimers = defaultShowInvasionTimers;
+    } else {
+        showInvasionTimers = (showInvasionTimersValue === 'true');
     }
 
     const showSpawnpointsValue = retrieve('show_spawnpoints');
@@ -675,22 +693,6 @@ function loadStorage () {
         showDevices = defaultShowDevices;
     } else {
         showDevices = (showDevicesValue === 'true');
-    }
-
-    const showRaidTimersValue = retrieve('show_raid_timers');
-    if (showRaidTimersValue === null) {
-        store('show_raid_timers', true); // TODO: Set default option in config
-        showRaidTimers = true;
-    } else {
-        showRaidTimers = (showRaidTimersValue === 'true');
-    }
-
-    const showInvasionTimersValue = retrieve('show_invasion_timers');
-    if (showInvasionTimersValue === null) {
-        store('show_invasion_timers', false); // TODO: Set default option in config
-        showInvasionTimers = false;
-    } else {
-        showInvasionTimers = (showInvasionTimersValue === 'true');
     }
 
     const pokemonFilterValue = retrieve('pokemon_filter');
@@ -809,7 +811,7 @@ function loadStorage () {
     if (raidFilterValue === null) {
         const defaultRaidFilter = {};
         if (defaultRaidFilter.timers === undefined) {
-            defaultRaidFilter.timers = { show: true, size: 'normal' };
+            defaultRaidFilter.timers = { show: defaultShowRaidTimers, size: 'normal' };
         }
         let i;
         for (i = 1; i <= 6; i++) {
@@ -926,7 +928,7 @@ function loadStorage () {
     if (invasionFilterValue === null) {
         const defaultInvasionFilter = {};
         if (defaultInvasionFilter.timers === undefined) {
-            defaultInvasionFilter.timers = { show: false, size: 'normal' };
+            defaultInvasionFilter.timers = { show: showInvasionTimers, size: 'normal' };
         }
         let i;
         for (i = 1; i <= 50; i++) {
@@ -6365,6 +6367,7 @@ function loadFilterSettings (e) {
 
         showRaidTimers = obj.show_raid_timers;
         store('show_raid_timers', showRaidTimers);
+
         showInvasionTimers = obj.show_invasion_timers;
         store('show_invasion_timers', showInvasionTimers);
 
@@ -6741,7 +6744,7 @@ function registerFilterButtonCallbacks() {
     // Raid filter buttons
     $('#reset-raid-filter').on('click', function (event) {
         const defaultRaidFilter = {};
-        defaultRaidFilter.timers = { show: true, size: 'normal' };
+        defaultRaidFilter.timers = { show: defaultShowRaidTimers, size: 'normal' };
         let i;
         for (i = 1; i <= 6; i++) {
             defaultRaidFilter['l' + i] = { show: true, size: 'normal' };
@@ -6882,7 +6885,7 @@ function registerFilterButtonCallbacks() {
     // Invasion filter buttons
     $('#reset-invasion-filter').on('click', function (event) {
         const defaultInvasionFilter = {};
-        defaultInvasionFilter.timers = { show: true, size: 'normal' };
+        defaultInvasionFilter.timers = { show: defaultShowInvasionTimers, size: 'normal' };
         for (let i = 1; i <= 50; i++) {
             defaultInvasionFilter['i' + i] = { show: true, size: 'normal' };
         }

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -928,7 +928,7 @@ function loadStorage () {
     if (invasionFilterValue === null) {
         const defaultInvasionFilter = {};
         if (defaultInvasionFilter.timers === undefined) {
-            defaultInvasionFilter.timers = { show: showInvasionTimers, size: 'normal' };
+            defaultInvasionFilter.timers = { show: defaultShowInvasionTimers, size: 'normal' };
         }
         let i;
         for (i = 1; i <= 50; i++) {

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -127,18 +127,18 @@ let skipForms = ['Shadow', 'Purified'];
 
 let defaultShowPokemon = '{{default_show_pokemon}}' === 'true';
 let defaultShowRaids = '{{default_show_raids}}' === 'true';
-let defaultShowRaidTimers = '{{default_show_raidTimers}}' === 'true';
+let defaultShowRaidTimers = '{{default_show_raid_timers}}' === 'true';
 let defaultShowGyms = '{{default_show_gyms}}' === 'true';
 let defaultShowPokestops = '{{default_show_pokestops}}' === 'true';
 let defaultShowQuests = '{{default_show_quests}}' === 'true';
 let defaultShowInvasions = '{{default_show_invasions}}' === 'true';
-let defaultShowInvasionTimers = '{{default_show_invasionTimers}}' === 'true';
+let defaultShowInvasionTimers = '{{default_show_invasion_timers}}' === 'true';
 let defaultShowSpawnpoints = '{{default_show_spawnpoints}}' === 'true';
 let defaultShowWeather = '{{default_show_weather}}' === 'true';
-let defaultShowScanCells = '{{default_show_scanCells}}' === 'true';
-let defaultShowSubmissionCells = '{{default_show_submissionCells}}' === 'true';
+let defaultShowScanCells = '{{default_show_scan_cells}}' === 'true';
+let defaultShowSubmissionCells = '{{default_show_submission_cells}}' === 'true';
 let defaultShowNests = '{{default_show_nests}}' === 'true';
-let defaultShowScanAreas = '{{default_show_scanAreas}}' === 'true';
+let defaultShowScanAreas = '{{default_show_scan_areas}}' === 'true';
 let defaultShowDevices = '{{default_show_devices}}' === 'true';
 
 const pokemonRarity = JSON.parse('{{{pokemon_rarity_json}}}');


### PR DESCRIPTION
Crossing off more random to do items. Contains config changes.

- Fixed a couple of camel case inconsistencies
- Add default options for Raid Timers
- Add default options for Invasion Timers
- Setting default for either also affects the result of the "Reset Filter" button for each of them.