### PR TITLE
Configurable Device Path Color

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ NodeJS Map clone replacement for [RealDeviceMap](https://github.com/realdevicema
         "minZoom": 10,
         // Map maximum zoom level
         "maxZoom": 18,
+        // Defines the color of 70m paths and Quest/IV Polygons
+        "devicePathColor": "red",
         // Clustering settings
         "clusters": {
             // Enable pokemon clustering

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -13,6 +13,7 @@
         "startZoom": 12,
         "minZoom": 10,
         "maxZoom": 18,
+        "devicePathColor": "red",
         "clusters": {
             "pokemon": true,
             "gyms": true,

--- a/src/data/default.js
+++ b/src/data/default.js
@@ -19,6 +19,7 @@ data.scouting_url = config.scouting.url;
 data.scouting_count = config.scouting.maxScouts;
 data.glow_color = config.map.glow.color;
 data.glow_iv = config.map.glow.iv;
+data.device_path_color = config.map.devicePathColor;
 
 // Default filter options for new users/cache clears
 data.default_show_pokemon = config.map.filters.pokemon;

--- a/src/views/index-js.mustache
+++ b/src/views/index-js.mustache
@@ -111,7 +111,6 @@ let clusters = L.markerClusterGroup({
     disableClusteringAtZoom: '{{cluster_zoom_level}}',
     removeOutsideVisibleBounds: true
 });
-
 let enableScouting = '{{scouting}}' === 'true';
 
 let currentPositionMarker;
@@ -3800,11 +3799,12 @@ function getDeviceMarker (device, ts) {
     marker.on('popupopen', function (popup) {
         openedDevice = device;
         marker._popup.setContent(getDevicePopupContent(device));
+        const data = JSON.parse(device.data);
+        const route = data.area;
         if (device.type === 'circle_pokemon') {
-            const data = JSON.parse(device.data);
-            const route = data.area;
-            // TODO: Make outline color configurable
-            polyline = L.polyline(route, {color: 'red'}).addTo(map);
+            polyline = L.polyline(route, {color: '{{device_path_color}}'}).addTo(map);
+        } else if (device.type == 'pokemon_iv' || 'auto_quest') {
+            polyline = L.polyline(route, {color: '{{device_path_color}}', fill: true, fillColor: '{{device_path_color}}'}).addTo(map);
         }
     });
     marker.on('popupclose', function (popup) {
@@ -5294,9 +5294,9 @@ function getCpAtLevel(id, level, isMax) {
     if (!masterfile.pokemon[id]) {
         return 0;
     }
-    if (cpMultipliers.level) {
+    if (cpMultipliers[level]) {
         let pkmn = masterfile.pokemon[id];
-        let multiplier = cpMultipliers.level;
+        let multiplier = cpMultipliers[level];
         let increment = isMax ? 15 : 10;
         let minAtk = ((pkmn.attack + increment) * multiplier) || 0;
         let minDef = ((pkmn.defense + increment) * multiplier) || 0;


### PR DESCRIPTION
**Contains Config Changes!**

- Addresses more hidden to do items from @versx 
- Adds IV/Quest instance polygons when clicking on a device
- Makes the color of the polyline/polygon configurable
- Fixes cpm typo :sweat: I don't know why it was working with ```.level``` (or why I changed it at all) 