### PR TITLE
Fix substitute pokemon by fetching synchronously

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -231,14 +231,13 @@ const updateAvailableForms = async (icons) => {
                 icon.pokemonList = availableForms;
             }
         } else if (!Array.isArray(icon.pokemonList) || Date.now() - icon.lastRetrieved > 60 * 60 * 1000) {
-            axios({
+            const response = await axios({
                 method: 'GET',
                 url: icon.path + '/index.json',
                 responseType: 'json'
-            }).then((response) => {
-                icon.pokemonList = response ? response.data : [];
-                icon.lastRetrieved = Date.now();
             });
+            icon.pokemonList = response ? response.data : [];
+            icon.lastRetrieved = Date.now();
         }
     }
 };


### PR DESCRIPTION
Fix the issue mentioned in #177. However, I still think this should be moved to client side.