### PR TITLE
Move pokemon up in candy to prevent overlapping with amount

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -3761,7 +3761,7 @@ function getPokestopMarkerIcon (pokestop, ts) {
             //iconUrl = `${availableIconStyles[selectedIconStyle].path}/item/-3.png`;
             iconUrl = '/img/item/-3.png';
             if (info && info.pokemon_id) {
-                iconHtml = `<img src="${availableIconStyles[selectedIconStyle].path}/${getPokemonIcon(info.pokemon_id)}.png"/>`;
+                iconHtml = `<img src="${availableIconStyles[selectedIconStyle].path}/${getPokemonIcon(info.pokemon_id)}.png" style="bottom: 15px;"/>`;
             }
             if (info && info.amount > 1) {
                 iconHtml += `<div class="amount-holder"><div>${info.amount}</div></div>`;
@@ -3795,7 +3795,7 @@ function getPokestopMarkerIcon (pokestop, ts) {
             rewardString = 'i-8';
             iconUrl = '/img/item/-8.png';
             if (info && info.pokemon_id) {
-                iconHtml = `<img src="${availableIconStyles[selectedIconStyle].path}/${getPokemonIcon(info.pokemon_id)}.png"/>`;
+                iconHtml = `<img src="${availableIconStyles[selectedIconStyle].path}/${getPokemonIcon(info.pokemon_id)}.png" style="bottom: 15px;"/>`;
             }
             if (info && info.amount > 1) {
                 iconHtml += `<div class="amount-holder"><div>${info.amount}</div></div>`;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3511321/93008235-794ca680-f540-11ea-93ca-31daa4d837df.png)

Currently offset is fixed `15px` since it only attempts to evade the amount (having line height `18px`), instead of 50% of the height of the icon.