### PR TITLE
fix: remove header links from default.json

### DIFF
--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -60,12 +60,8 @@
         }
     },
     "header": {
-        "left": [
-            { "name": "Stats", "url": "https://stats.example.com", "icon": "fas fa-chart-bar" }
-        ],
-        "right": [
-            { "name": "Discord", "url": "https://discord.com", "icon": "fab fa-discord" }
-        ]
+        "left": [],
+        "right": []
     },
     "db": {
         "scanner": {


### PR DESCRIPTION
These will be always be super customized and should only exist in the `config.json`. Our config.example file already has the sample links. This makes the merge between the two settings easier as Stats & Discord might not exist for all maps.