### PR TITLE
Support NOT and CP in IV filters

### DIFF
--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1231,7 +1231,7 @@ const getPolygon = (s2cellId) => {
 // need to keep consistency with client-side implementation checkIVFilterValid
 const sqlifyIvFilter = (filter) => {
     const input = filter.toUpperCase();
-    let tokenizer = /\s*([()|&!]|([ADSL]?|CP)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
+    let tokenizer = /\s*([()|&!]|([ADSL]?|CP)\s*([0-9]+(?:\.[0-9]*)?)(?:\s*-\s*([0-9]+(?:\.[0-9]*)?))?)/g;
     let result = '';
     let expectClause = true;    // expect a clause or '('
     let stack = 0;

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1230,13 +1230,14 @@ const getPolygon = (s2cellId) => {
 
 // need to keep consistency with client-side implementation checkIVFilterValid
 const sqlifyIvFilter = (filter) => {
+    const input = filter.toUpperCase();
     let tokenizer = /\s*([()|&!]|([ADSL]?|CP)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
     let result = '';
     let expectClause = true;    // expect a clause or '('
     let stack = 0;
     let lastIndex = 0;
     let match;
-    while ((match = tokenizer.exec(filter)) !== null) {
+    while ((match = tokenizer.exec(input)) !== null) {
         if (match.index > lastIndex) {
             return null;
         }

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1230,7 +1230,7 @@ const getPolygon = (s2cellId) => {
 
 // need to keep consistency with client-side implementation checkIVFilterValid
 const sqlifyIvFilter = (filter) => {
-    let tokenizer = /\s*([()|&!]|([ADSL]?)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
+    let tokenizer = /\s*([()|&!]|([ADSL]?|CP)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
     let result = '';
     let expectClause = true;    // expect a clause or '('
     let stack = 0;
@@ -1249,6 +1249,7 @@ const sqlifyIvFilter = (filter) => {
                     case 'D': column = 'def_iv'; break;
                     case 'S': column = 'sta_iv'; break;
                     case 'L': column = 'level';  break;
+                    case 'CP': column = 'cp';    break;
                 }
                 let higher = lower;
                 if (match[4] !== undefined) {

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1228,8 +1228,9 @@ const getPolygon = (s2cellId) => {
     return polygon;
 };
 
+// need to keep consistency with client-side implementation checkIVFilterValid
 const sqlifyIvFilter = (filter) => {
-    let tokenizer = /\s*([()|&]|([ADSL]?)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
+    let tokenizer = /\s*([()|&!]|([ADSL]?)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
     let result = '';
     let expectClause = true;    // expect a clause or '('
     let stack = 0;
@@ -1255,18 +1256,25 @@ const sqlifyIvFilter = (filter) => {
                 }
                 result += `(${column} IS NOT NULL AND ${column} >= ${lower} AND ${column} <= ${higher})`;
                 expectClause = false;
-            } else if (match[1] === '(') {
-                if (++stack > 1000000000) {
+            } else switch (match[1]) {
+                case '(':
+                    if (++stack > 1000000000) {
+                        return null;
+                    }
+                    result += '(';
+                    break;
+                case '!':
+                    result += 'NOT ';
+                    break;
+                default:
                     return null;
-                }
-                result += '(';
-            } else {
-                return null;
             }
         } else if (match[3] !== undefined) {
             return null;
         } else switch (match[1]) {
-            case '(': return null;
+            case '(':
+            case '!':
+                return null;
             case ')':
                 result += ')';
                 if (--stack < 0) {
@@ -1274,11 +1282,11 @@ const sqlifyIvFilter = (filter) => {
                 }
                 break;
             case '&':
-                result += 'AND';
+                result += 'AND ';
                 expectClause = true;
                 break;
             case '|':
-                result += 'OR';
+                result += 'OR ';
                 expectClause = true;
                 break;
         }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5153,8 +5153,10 @@ function getTimeSince (date) {
     return str;
 }
 
+const ivFilterPrompt = 'Please enter an IV Filter. Example: (S0-1 & A15 & D15 & (C1400-1500 | C2400-2500)) | L35 | 90-100';
+
 function manageIVPopup (id, filter) {
-    const result = prompt('Please enter an IV Filter. Example: (S0-1 & A15 & D15 & L0-20) | L35 | 90-100', filter[id].filter).toUpperCase();
+    const result = prompt(ivFilterPrompt, filter[id].filter).toUpperCase();
     const prevShow = filter[id].show;
     let success;
     if (result == null) {
@@ -5206,7 +5208,7 @@ function manageColorPopup (id, filter) {
 }
 
 function manageGlobalIVPopup (id, filter) {
-    const result = prompt('Please enter an IV Filter. Example: (S0-1 & A15 & D15 & L0-20) | L35 | 90-100', filter['iv_' + id].filter);
+    const result = prompt(ivFilterPrompt, filter['iv_' + id].filter);
     if (result === null) {
         return false;
     } else if (checkIVFilterValid(result)) {
@@ -5271,7 +5273,7 @@ function manageGlobalStardustCountPopup (id, filter) {
 }
 
 function checkIVFilterValid (filter) {
-    let tokenizer = /\s*([()|&!]|([ADSL]?)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
+    let tokenizer = /\s*([()|&!]|([ADSL]?|CP)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
     let expectClause = true;
     let stack = 0;
     let lastIndex = 0;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5153,7 +5153,7 @@ function getTimeSince (date) {
     return str;
 }
 
-const ivFilterPrompt = 'Please enter an IV Filter. Example: (S0-1 & A15 & D15 & (C1400-1500 | C2400-2500)) | L35 | 90-100';
+const ivFilterPrompt = 'Please enter an IV Filter. Example: (S0-1 & A15 & D15 & (CP1400-1500 | CP2400-2500)) | L35 | 90-100';
 
 function manageIVPopup (id, filter) {
     const result = prompt(ivFilterPrompt, filter[id].filter).toUpperCase();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5271,7 +5271,7 @@ function manageGlobalStardustCountPopup (id, filter) {
 }
 
 function checkIVFilterValid (filter) {
-    let tokenizer = /\s*([()|&]|([ADSL]?)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
+    let tokenizer = /\s*([()|&!]|([ADSL]?)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
     let expectClause = true;
     let stack = 0;
     let lastIndex = 0;
@@ -5283,17 +5283,23 @@ function checkIVFilterValid (filter) {
         if (expectClause) {
             if (match[3] !== undefined) {
                 expectClause = false;
-            } else if (match[1] === '(') {
-                if (++stack > 1000000000) {
+            } else switch (match[1]) {
+                case '(':
+                    if (++stack > 1000000000) {
+                        return null;
+                    }
+                    break;
+                case '!':
+                    break;
+                default:
                     return null;
-                }
-            } else {
-                return null;
             }
         } else if (match[3] !== undefined) {
             return null;
         } else switch (match[1]) {
-            case '(': return null;
+            case '(':
+            case '!':
+                return null;
             case ')':
                 if (--stack < 0) {
                     return null;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5156,7 +5156,7 @@ function getTimeSince (date) {
 const ivFilterPrompt = 'Please enter an IV Filter. Example: (S0-1 & A15 & D15 & (CP1400-1500 | CP2400-2500)) | L35 | 90-100';
 
 function manageIVPopup (id, filter) {
-    const result = prompt(ivFilterPrompt, filter[id].filter).toUpperCase();
+    const result = prompt(ivFilterPrompt, filter[id].filter);
     const prevShow = filter[id].show;
     let success;
     if (result == null) {
@@ -5273,12 +5273,13 @@ function manageGlobalStardustCountPopup (id, filter) {
 }
 
 function checkIVFilterValid (filter) {
+    const input = filter.toUpperCase();
     let tokenizer = /\s*([()|&!]|([ADSL]?|CP)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
     let expectClause = true;
     let stack = 0;
     let lastIndex = 0;
     let match;
-    while ((match = tokenizer.exec(filter)) !== null) {
+    while ((match = tokenizer.exec(input)) !== null) {
         if (match.index > lastIndex) {
             return null;
         }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5274,7 +5274,7 @@ function manageGlobalStardustCountPopup (id, filter) {
 
 function checkIVFilterValid (filter) {
     const input = filter.toUpperCase();
-    let tokenizer = /\s*([()|&!]|([ADSL]?|CP)([0-9]+(?:\.[0-9]*)?)(?:-([0-9]+(?:\.[0-9]*)?))?)/g;
+    let tokenizer = /\s*([()|&!]|([ADSL]?|CP)\s*([0-9]+(?:\.[0-9]*)?)(?:\s*-\s*([0-9]+(?:\.[0-9]*)?))?)/g;
     let expectClause = true;
     let stack = 0;
     let lastIndex = 0;


### PR DESCRIPTION
NOT could be useful for including pokemon with missing IVs, e.g. `!0-100` will give you `"NOT (iv IS NOT NULL AND iv >= 0 AND iv <= 100)"`.

CP is useful for obvious reasons.

Probably needs testing.